### PR TITLE
docs: add component and end-user documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to MaticOS will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial `matic-init` implementation (PID 1 with process supervision).
+- Initial `matic-agent` gRPC server with status and install endpoints.
+- Initial `osctl` CLI client.
+- Docker-based build environment (`tools/builder/`).
+- Kernel build script with minimal x86_64 configuration.
+- Initramfs build script bundling all components.
+- QEMU-based testing harness (`tools/testing/`).
+- A/B partition update mechanism prototype.
+
+### Changed
+- N/A
+
+### Fixed
+- N/A
+
+### Security
+- N/A
+
+---
+
+## [0.1.0] - YYYY-MM-DD (Planned)
+
+Initial alpha release.

--- a/cmd/matic-agent/README.md
+++ b/cmd/matic-agent/README.md
@@ -1,0 +1,32 @@
+# matic-agent
+
+The API endpoint for MaticOS node management.
+
+**Status**: Alpha
+**Language**: Rust
+**Communication**: gRPC (mTLS)
+
+## Overview
+
+`matic-agent` runs as a daemon (supervised by `matic-init`) and exposes a gRPC interface. Since MaticOS has no SSH or shell, this agent is the *only* way to mutate the system state or retrieve debug information remotely.
+
+## Features
+
+*   **Install/Update**: Accepting new OS images and writing them to the passive partition.
+*   **Reboot**: Safe reboot handling.
+*   **Network Configuration**: Applying IP addresses, routes, and DNS settings.
+*   **Observability**: Streaming logs from system components (`containerd`, `kubelet`) and providing kernel metrics.
+
+## API Specs
+
+The Protocol Buffer definitions are located in `crates/matic-proto`.
+
+## Usage
+
+Started automatically by `matic-init`.
+Listens on `0.0.0.0:50051`.
+
+Debug locally (if built natively):
+```bash
+cargo run --package matic-agent
+```

--- a/cmd/matic-init/README.md
+++ b/cmd/matic-init/README.md
@@ -1,0 +1,39 @@
+# matic-init
+
+The PID 1 init process for MaticOS.
+
+**Status**: Alpha
+**Language**: Rust
+
+## Responsibilities
+
+`matic-init` is the first process launched by the kernel. Unlike `systemd` or `sysvinit`, it is not a general-purpose service manager. Its scope is strictly bounded:
+
+1.  **Early Boot**:
+    *   Mounts pseudo-filesystems (`/proc`, `/sys`, `/dev`, `/run`, `/sys/fs/cgroup`).
+    *   Populates `/dev` using `devtmpfs`.
+2.  **Storage Setup**:
+    *   Scans block devices for the `MATIC_STATE` partition.
+    *   Mounts the persistent overlay filesystem.
+3.  **Networking**:
+    *   Configures the loopback interface (`lo`).
+    *   (Future) Sets up minimal host networking (DHCP or static).
+4.  **Supervisor**:
+    *   Starts and supervises `containerd`.
+    *   Starts and supervises `kubelet`.
+    *   Starts and supervises `matic-agent`.
+5.  **Reaper**:
+    *   Reaps orphaned zombie processes to prevent resource exhaustion.
+6.  **Shutdown**:
+    *   Handles `SIGTERM`/`SIGINT` to gracefully shut down services and unmount filesystems.
+
+## Configuration
+
+`matic-init` is largely zero-config, relying on convention (e.g., standard mount paths) rather than configuration files. However, it may read kernel command-line arguments (e.g., `matic.debug`) to toggle verbose logging.
+
+## Development
+
+To build:
+```bash
+cargo build --package matic-init --target x86_64-unknown-linux-musl
+```

--- a/cmd/osctl/README.md
+++ b/cmd/osctl/README.md
@@ -1,0 +1,36 @@
+# osctl
+
+The Command Line Interface for administering MaticOS nodes.
+
+**Status**: Alpha
+**Language**: Rust
+
+## Overview
+
+`osctl` is a remote client that talks to `matic-agent` via gRPC. It mimics a standard CLI tool but executes operations remotely.
+
+## Usage
+
+```bash
+# Get node status
+osctl --addr <NODE_IP>:50051 status
+
+# Install a new OS version
+osctl --addr <NODE_IP>:50051 install --image <OCI_IMAGE_URL> --version 1.0.1
+
+# Reboot the node
+osctl --addr <NODE_IP>:50051 reboot
+
+# Stream logs
+osctl --addr <NODE_IP>:50051 logs --component kubelet
+```
+
+## Configuration
+
+Credentials and default endpoints can be stored in `~/.config/osctl.yaml` (Planned).
+
+## Build
+
+```bash
+cargo build --package osctl
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Documentation
+
+This directory contains end-user documentation, architectural guides, and reference materials for MaticOS.
+
+## Guides
+
+| Document | Description |
+|----------|-------------|
+| [Getting Started](./getting-started.md) | Build MaticOS from source and run it locally. |
+| [Using osctl](./using-osctl.md) | Remote administration with the `osctl` CLI. |
+| [Architecture](./architecture.md) | System design, boot sequence, and update mechanism. |
+
+## Release Notes
+
+See [CHANGELOG.md](../CHANGELOG.md) in the project root.
+
+## Contributing Documentation
+
+1.  **Format**: Use Markdown.
+2.  **Location**: User-facing docs go here. Internal/developer docs go in component `README.md` files.
+3.  **Review**: All documentation changes require PR review.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,67 @@
+# MaticOS Architecture
+
+This document provides a high-level overview of the MaticOS architecture.
+
+## Design Principles
+
+1.  **Immutable**: The OS runs from a read-only SquashFS image. No package manager. No runtime modifications.
+2.  **API-Driven**: All management happens via gRPC, not SSH.
+3.  **Minimal Attack Surface**: No shell, no interpreters (Python/Perl), no unnecessary services.
+4.  **Atomic Updates**: A/B partition scheme ensures safe, rollback-capable updates.
+
+## Boot Sequence
+
+```mermaid
+sequenceDiagram
+    participant BIOS/UEFI
+    participant Kernel
+    participant matic-init
+    participant containerd
+    participant kubelet
+    participant matic-agent
+
+    BIOS/UEFI->>Kernel: Load bzImage + initramfs
+    Kernel->>matic-init: Execute /init (PID 1)
+    matic-init->>matic-init: Mount /proc, /sys, /dev
+    matic-init->>matic-init: Mount persistent storage
+    matic-init->>containerd: Start containerd
+    matic-init->>kubelet: Start kubelet
+    matic-init->>matic-agent: Start gRPC agent
+    matic-agent-->>matic-agent: Listen on :50051
+```
+
+## Component Responsibilities
+
+| Component       | Role                                      |
+|-----------------|-------------------------------------------|
+| `matic-init`    | PID 1. Mounts filesystems, supervises processes, reaps zombies. |
+| `matic-agent`   | gRPC server. Handles updates, reboots, configuration. |
+| `osctl`         | CLI client for `matic-agent`. |
+| `containerd`    | Container runtime (stock, unmodified). |
+| `kubelet`       | Kubernetes node agent (stock, unmodified). |
+
+## Partition Layout
+
+MaticOS uses a GPT partition table with the following layout:
+
+| Partition | Label         | Purpose                        |
+|-----------|---------------|--------------------------------|
+| 1         | `ESP`         | EFI System Partition (unused in direct kernel boot) |
+| 2         | `MATIC_ROOT_A`| Primary OS image (SquashFS)    |
+| 3         | `MATIC_ROOT_B`| Secondary OS image (for updates) |
+| 4         | `MATIC_STATE` | Persistent data (overlay, etcd, logs) |
+
+## Update Mechanism
+
+1.  `osctl install` downloads a new SquashFS image.
+2.  The image is written to the *inactive* partition (e.g., if booted from A, write to B).
+3.  Boot flags are updated to boot from the new partition.
+4.  On `osctl reboot`, the system boots into the new version.
+5.  If the new version fails to boot, a watchdog triggers a rollback to the previous partition.
+
+## Security Model
+
+*   **mTLS**: All gRPC communication is secured with mutual TLS.
+*   **Kernel Lockdown**: (Planned) Prevents runtime modification of kernel memory.
+*   **Read-Only Root**: No writable paths on the OS image.
+*   **No Passwords**: No user accounts. No `/etc/passwd`. No login.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,83 @@
+# Getting Started with MaticOS
+
+This guide walks you through building MaticOS from source and running it locally in QEMU.
+
+## Prerequisites
+
+*   **Docker**: Required to run the hermetic build environment.
+*   **QEMU**: Required for local testing (`qemu-system-x86_64`).
+*   A host machine with at least 4GB RAM and 10GB free disk space.
+
+## Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/scheeles/maticos.git
+cd maticos
+```
+
+## Step 2: Enter the Build Environment
+
+The build environment is a Docker container with all necessary toolchains pre-installed.
+
+```bash
+./tools/builder/build.sh
+```
+
+This will:
+1.  Build the `maticos-builder` Docker image (first run only).
+2.  Drop you into an interactive shell inside the container.
+
+## Step 3: Build the Kernel
+
+Inside the container, run:
+
+```bash
+./tools/builder/kernel-build.sh
+```
+
+This downloads the Linux kernel source, applies MaticOS-specific configuration, and compiles `bzImage`.
+
+**Output**: `build/kernel/bzImage`
+
+## Step 4: Build the Rust Components
+
+Still inside the container:
+
+```bash
+cargo build --release --target x86_64-unknown-linux-musl
+```
+
+This compiles `matic-init`, `matic-agent`, and `osctl`.
+
+## Step 5: Build the Initramfs
+
+```bash
+./tools/builder/initramfs-build.sh
+```
+
+This assembles all binaries, libraries, and configurations into a bootable initramfs.
+
+**Output**: `build/initramfs.cpio.gz`
+
+## Step 6: Create a Test Disk
+
+```bash
+./tools/testing/setup-test-disk.sh
+```
+
+This creates a mock disk image (`build/sda.img`) with the required partition layout.
+
+## Step 7: Boot in QEMU
+
+Exit the Docker container (type `exit`) and run on your host:
+
+```bash
+./tools/testing/run-qemu.sh
+```
+
+You should see the MaticOS boot sequence. The system will initialize and start `matic-agent`.
+
+## Next Steps
+
+*   [Using osctl](./using-osctl.md) - Learn how to interact with a running MaticOS node.
+*   [Architecture Overview](./architecture.md) - Understand how MaticOS is designed.

--- a/docs/using-osctl.md
+++ b/docs/using-osctl.md
@@ -1,0 +1,70 @@
+# Using osctl
+
+`osctl` is the command-line tool for managing MaticOS nodes remotely. Since MaticOS has no SSH or shell access, `osctl` is the primary interface for administration.
+
+## Connecting to a Node
+
+Every command requires a target node address:
+
+```bash
+osctl --addr <NODE_IP>:50051 <command>
+```
+
+When testing locally with QEMU (using `run-qemu.sh`), the agent is forwarded to `localhost:50052`:
+
+```bash
+osctl --addr 127.0.0.1:50052 <command>
+```
+
+## Commands
+
+### Check Node Status
+
+```bash
+osctl --addr 127.0.0.1:50052 status
+```
+
+Returns system information including:
+*   OS version
+*   Uptime
+*   Active partition (A or B)
+*   Kubelet status
+
+### Install an Update
+
+```bash
+osctl --addr 127.0.0.1:50052 install --image oci://registry.example.com/maticos:1.0.1
+```
+
+This downloads the new OS image and writes it to the inactive partition. After installation, reboot to activate.
+
+### Reboot the Node
+
+```bash
+osctl --addr 127.0.0.1:50052 reboot
+```
+
+Initiates a graceful shutdown of all services and reboots into the newly installed partition.
+
+### Stream Logs
+
+```bash
+osctl --addr 127.0.0.1:50052 logs --component kubelet
+osctl --addr 127.0.0.1:50052 logs --component containerd
+osctl --addr 127.0.0.1:50052 logs --component agent
+```
+
+Streams real-time logs from the specified component.
+
+### Network Configuration (Planned)
+
+```bash
+osctl --addr 127.0.0.1:50052 network set --ip 10.0.0.5/24 --gateway 10.0.0.1
+```
+
+## Authentication
+
+> [!NOTE]
+> mTLS authentication is planned but not yet implemented in the alpha release.
+
+In production, `osctl` will require client certificates to authenticate with the agent.

--- a/tools/builder/README.md
+++ b/tools/builder/README.md
@@ -1,21 +1,57 @@
-# Builder
+# Builder Tools
 
-The `builder` directory provides a consistent build environment for MaticOS, packaged as a Docker container.
+The `builder` directory provides a hermetic build environment for MaticOS, packaged as a Docker container. This ensures consistent builds across different host operating systems (macOS, Linux, Windows).
 
-Since MaticOS is a Linux distribution, it must be built on Linux. This builder ensures that macOS and Windows users can build the OS correctly.
+## Scripts
 
-## Usage
+### `build.sh`
 
-1.  **Start the Builder Shell**:
-    ```bash
-    ./tools/builder/build.sh
-    ```
-    This drops you into a shell inside the container with tools (`cargo`, `make`, `gcc`) installed.
+**Usage**: `./tools/builder/build.sh`
 
-2.  **Inside the Container**:
-    You can run build scripts (to be created) like:
-    ```bash
-    # (Future)
-    # cargo build --release
-    # ./tools/builder/kernel.sh
-    ```
+This is the main entry point. It:
+1.  Builds the `maticos-builder` Docker image (defined in `Dockerfile` in this directory).
+2.  Launches an interactive shell inside the container.
+3.  Mounts the project root to `/maticos`.
+4.  Caches `~/.cargo/registry` and `/maticos/target` to host volumes for faster subsequent builds.
+
+**Environment**:
+Inside the container, you have access to:
+*   `cargo` / `rustc` (Nightly/Stable)
+*   `gcc` (Cross-compilers)
+*   `make`, `bison`, `flex` (Kernel build tools)
+*   `protobuf-compiler` (for gRPC)
+
+### `kernel-build.sh`
+
+**Usage**: `./tools/builder/kernel-build.sh` (Inside the builder container)
+
+Automates the Linux Kernel build process:
+1.  **Downloads**: Fetches the specified Linux Kernel tarball (e.g., 6.6.x).
+2.  **Configures**: Applies a minimal `x86_64_defconfig` and enables critical MaticOS features:
+    *   `CONFIG_SQUASHFS`: For the immutable root filesystem.
+    *   `CONFIG_OVERLAY_FS`: For container storage.
+    *   `CONFIG_BLK_DEV_INITRD`: For initramfs support.
+    *   `CONFIG_PVH`: For efficient booting in QEMU/Firecracker.
+3.  **Builds**: Compiles the kernel using `make bzImage`.
+4.  **Artifact**: Outputs `build/kernel/bzImage`.
+
+### `initramfs-build.sh`
+
+**Usage**: `./tools/builder/initramfs-build.sh` (Inside the builder container)
+
+Assembles the initial RAM filesystem used by the kernel at boot.
+1.  **Directory Structure**: Creates the standard Linux hierarchy (`/bin`, `/etc`, `/proc`, etc.).
+2.  **Binaries**:
+    *   Copies `matic-init` (PID 1) to `/init`.
+    *   Copies `matic-agent` and `osctl` to `/usr/bin/`.
+    *   Copies `containerd`, `runc`, and CNI plugins.
+    *   Copies statically linked `busybox` for debugging shell.
+3.  **Libraries**: Copies required GLIBC libraries for dynamic binaries (like stock `kubelet`).
+4.  **Packaging**: Packs the directory tree into `build/initramfs.cpio.gz`.
+
+## Build Artifacts
+
+All artifacts are output to the `build/` directory in the project root:
+
+*   `build/kernel/bzImage`: The bootable kernel.
+*   `build/initramfs.cpio.gz`: The root filesystem.

--- a/tools/testing/README.md
+++ b/tools/testing/README.md
@@ -1,0 +1,42 @@
+# Testing Tools
+
+This directory contains scripts for verification, local development, and end-to-end testing of MaticOS.
+
+## Local Development
+
+### `run-qemu.sh`
+
+**Usage**: `./tools/testing/run-qemu.sh`
+
+Boots the locally built MaticOS artifacts in QEMU.
+*   **Kernel**: `build/kernel/bzImage`
+*   **Initramfs**: `build/initramfs.cpio.gz`
+*   **Disk**: `build/sda.img` (Mock data drive)
+*   **Networking**:
+    *   Maps host port `50052` to guest port `50051` (gRPC Agent).
+    *   Console output is redirected to `stdout`.
+
+## Verification Scripts
+
+### `verify-artifacts.sh`
+
+Checks if all required build artifacts (kernel, initramfs, binary components) exist in the `build/` directory. Useful to run before starting tests.
+
+### `test-boot.sh`
+
+Runs a "smoke test" by booting the OS in QEMU and verifying that it reaches a "ready" state (e.g., `matic-init` started successfully) without panicking.
+
+### `test-integration.sh` / `test-update-flow.sh`
+
+Runs detailed end-to-end scenarios:
+*   **Update Flow**: Tests the A/B partition swap and OTA update mechanism.
+*   **Integration**: Verifies that `matic-agent` allows `osctl` connections and can spawn containers.
+
+## Setup
+
+### `setup-test-disk.sh`
+
+Creates a mock `sda.img` disk image with:
+*   GPT Partition Table.
+*   EFI System Partition (ESP).
+*   Correct partition labels (e.g., `MATIC_STATE`) required by `matic-init` to mount persistent storage.


### PR DESCRIPTION
- Update tools/builder/README.md with detailed script docs
- Add tools/testing/README.md for QEMU and test scripts
- Add README.md for matic-init, matic-agent, osctl
- Create docs/ with getting-started, using-osctl, architecture guides
- Add CHANGELOG.md following Keep a Changelog format