### PR TITLE
feat: add cross-platform osctl builds

### DIFF
--- a/.github/workflows/release-osctl.yml
+++ b/.github/workflows/release-osctl.yml
@@ -1,0 +1,130 @@
+name: Release osctl
+
+on:
+  push:
+    tags:
+      - 'osctl-v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., v0.1.0)'
+        required: true
+        default: 'v0.1.0'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-linux-windows:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-musl
+            name: Linux_arm64
+          - target: arm-unknown-linux-musleabihf
+            name: Linux_armv6
+          - target: armv7-unknown-linux-musleabihf
+            name: Linux_armv7
+          - target: x86_64-unknown-linux-musl
+            name: Linux_x86
+          - target: x86_64-pc-windows-gnu
+            name: Windows_x86
+            ext: .exe
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Build
+        run: cross build --release --package osctl --target ${{ matrix.target }}
+
+      - name: Prepare artifact
+        run: |
+          mkdir -p dist/${{ matrix.name }}
+          cp target/${{ matrix.target }}/release/osctl${{ matrix.ext }} dist/${{ matrix.name }}/osctl${{ matrix.ext }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: osctl-${{ matrix.name }}
+          path: dist/${{ matrix.name }}
+
+  build-macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            name: Darwin_arm64
+          - target: x86_64-apple-darwin
+            name: Darwin_x86
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install protoc
+        run: brew install protobuf
+
+      - name: Build
+        run: cargo build --release --package osctl --target ${{ matrix.target }}
+
+      - name: Prepare artifact
+        run: |
+          mkdir -p dist/${{ matrix.name }}
+          cp target/${{ matrix.target }}/release/osctl dist/${{ matrix.name }}/osctl
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: osctl-${{ matrix.name }}
+          path: dist/${{ matrix.name }}
+
+  release:
+    needs: [build-linux-windows, build-macos]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create archives
+        run: |
+          cd artifacts
+          for dir in osctl-*/; do
+            name="${dir%/}"
+            platform="${name#osctl-}"
+            cd "$name"
+            if [[ "$platform" == Windows* ]]; then
+              zip -r "../${name}.zip" .
+            else
+              chmod +x osctl
+              tar -czvf "../${name}.tar.gz" .
+            fi
+            cd ..
+          done
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            artifacts/*.tar.gz
+            artifacts/*.zip
+          generate_release_notes: true

--- a/tools/build-osctl.sh
+++ b/tools/build-osctl.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+set -e
+
+# Build osctl for multiple platforms using cross-rs
+# Usage: ./tools/build-osctl.sh [target...]
+# If no targets specified, builds all platforms
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${PROJECT_ROOT}/build/osctl"
+
+# All supported targets
+ALL_TARGETS=(
+    "aarch64-apple-darwin"        # Darwin_arm64
+    "x86_64-apple-darwin"         # Darwin_x86
+    "aarch64-unknown-linux-musl"  # Linux_arm64
+    "arm-unknown-linux-musleabihf"    # Linux_armv6
+    "armv7-unknown-linux-musleabihf"  # Linux_armv7
+    "x86_64-unknown-linux-musl"   # Linux_x86
+    "x86_64-pc-windows-gnu"       # Windows_x86
+)
+
+# Map Rust targets to friendly names
+get_friendly_name() {
+    case "$1" in
+        "aarch64-apple-darwin") echo "Darwin_arm64" ;;
+        "x86_64-apple-darwin") echo "Darwin_x86" ;;
+        "aarch64-unknown-linux-musl") echo "Linux_arm64" ;;
+        "arm-unknown-linux-musleabihf") echo "Linux_armv6" ;;
+        "armv7-unknown-linux-musleabihf") echo "Linux_armv7" ;;
+        "x86_64-unknown-linux-musl") echo "Linux_x86" ;;
+        "x86_64-pc-windows-gnu") echo "Windows_x86" ;;
+        *) echo "$1" ;;
+    esac
+}
+
+# Get binary extension
+get_extension() {
+    case "$1" in
+        *windows*) echo ".exe" ;;
+        *) echo "" ;;
+    esac
+}
+
+# Check if target needs cross (non-native)
+needs_cross() {
+    local target="$1"
+    local host_arch=$(uname -m)
+    local host_os=$(uname -s)
+    
+    # macOS targets can be built natively on macOS
+    if [[ "$host_os" == "Darwin" ]]; then
+        case "$target" in
+            *apple-darwin*) return 1 ;;  # Native build
+        esac
+    fi
+    
+    # Linux x86_64 can be built natively on Linux x86_64
+    if [[ "$host_os" == "Linux" && "$host_arch" == "x86_64" ]]; then
+        case "$target" in
+            "x86_64-unknown-linux-musl") return 1 ;;  # Native build with musl
+        esac
+    fi
+    
+    return 0  # Needs cross
+}
+
+# Install cross if needed
+ensure_cross() {
+    if ! command -v cross &> /dev/null; then
+        echo ">>> Installing cross-rs..."
+        cargo install cross --git https://github.com/cross-rs/cross
+    fi
+}
+
+# Build for a single target
+build_target() {
+    local target="$1"
+    local friendly_name=$(get_friendly_name "$target")
+    local ext=$(get_extension "$target")
+    
+    echo ">>> Building osctl for ${friendly_name} (${target})..."
+    
+    mkdir -p "${OUTPUT_DIR}/${friendly_name}"
+    
+    if needs_cross "$target"; then
+        ensure_cross
+        cross build --release --package osctl --target "$target"
+    else
+        # Add target if not installed
+        rustup target add "$target" 2>/dev/null || true
+        cargo build --release --package osctl --target "$target"
+    fi
+    
+    # Copy binary to output directory
+    local src="${PROJECT_ROOT}/target/${target}/release/osctl${ext}"
+    local dst="${OUTPUT_DIR}/${friendly_name}/osctl${ext}"
+    
+    if [[ -f "$src" ]]; then
+        cp "$src" "$dst"
+        echo "    Created: ${dst}"
+    else
+        echo "    ERROR: Binary not found at ${src}"
+        return 1
+    fi
+}
+
+# Main
+cd "$PROJECT_ROOT"
+mkdir -p "$OUTPUT_DIR"
+
+# Determine targets to build
+if [[ $# -gt 0 ]]; then
+    TARGETS=("$@")
+else
+    TARGETS=("${ALL_TARGETS[@]}")
+fi
+
+echo ">>> Building osctl for ${#TARGETS[@]} target(s)..."
+echo ""
+
+for target in "${TARGETS[@]}"; do
+    build_target "$target"
+    echo ""
+done
+
+echo ">>> Build complete! Binaries are in: ${OUTPUT_DIR}"
+ls -la "${OUTPUT_DIR}"


### PR DESCRIPTION
## Summary

Adds cross-platform build support for the osctl CLI tool, enabling builds for 7 target platforms.

## New Files

- `tools/build-osctl.sh` - Local build script using cross-rs for cross-compilation
- `.github/workflows/release-osctl.yml` - CI workflow for automated releases

## Supported Platforms

| Platform | Rust Target |
|----------|-------------|
| Darwin_arm64 | aarch64-apple-darwin |
| Darwin_x86 | x86_64-apple-darwin |
| Linux_arm64 | aarch64-unknown-linux-musl |
| Linux_armv6 | arm-unknown-linux-musleabihf |
| Linux_armv7 | armv7-unknown-linux-musleabihf |
| Linux_x86 | x86_64-unknown-linux-musl |
| Windows_x86 | x86_64-pc-windows-gnu |

## Usage

### Local build
```bash
./tools/build-osctl.sh                    # Build all platforms
./tools/build-osctl.sh x86_64-apple-darwin  # Build single target
```

### Release
Push a tag like `osctl-v0.1.0` to trigger the release workflow, which creates a GitHub Release with downloadable binaries.