### PR TITLE
feat: kubelet TLS bootstrap for cluster join

### DIFF
--- a/.ai-context/STYLE_GUIDE.md
+++ b/.ai-context/STYLE_GUIDE.md
@@ -53,6 +53,16 @@ This document defines the rules for contributing to KeelOS.
 3.  **E2E Tests**: Significant system-wide changes (e.g., networking, container lifecycle) require end-to-end tests using the project's QEMU-based testing framework.
 4.  **No Regressions**: All existing tests and verification scripts must pass before merging.
 
+## GitHub Interactions
+
+- **Always use the GitHub CLI (`gh`) for all GitHub operations**
+- Use `gh pr`, `gh run`, `gh api` instead of browser interactions
+- Examples:
+  - View PR checks: `gh pr checks <pr-number>`
+  - View run logs: `gh run view <run-id> --log`
+  - Check run status: `gh run list --branch <branch>`
+- Only use the browser for creating PRs when the CLI prompt is insufficient
+
 ## Commit Strategy
 
 1.  **Feature Branches**: All work must be performed in feature branches. Never commit directly to `main`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/kernel
-          key: ${{ runner.os }}-kernel-build-${{ hashFiles('tools/builder/kernel-build.sh', 'tools/builder/kernel-config') }}
-          restore-keys: |
-            ${{ runner.os }}-kernel-build-
+          key: ${{ runner.os }}-kernel-build-v2-${{ hashFiles('tools/builder/kernel-build.sh') }}
 
       - name: Build Builder Image
         uses: docker/build-push-action@v5
@@ -126,6 +124,14 @@ jobs:
             --privileged \
             keelos-builder:latest \
             /keelos/tools/ci-build-only.sh
+
+      - name: Free Disk Space
+        run: |
+          # Remove release target dir (only debug target needed for tests)
+          sudo rm -rf target/x86_64-unknown-linux-musl/release/deps target/x86_64-unknown-linux-musl/release/build || true
+          # Remove kernel source tree (large, no longer needed)
+          sudo rm -rf /tmp/kernel-build || true
+          df -h .
 
       - name: Run Unit Tests
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -3036,9 +3036,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -3057,9 +3057,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/cmd/keel-agent/src/main.rs
+++ b/cmd/keel-agent/src/main.rs
@@ -875,7 +875,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let bootstrap_ca_dir = "/var/lib/keel/crypto/trusted-clients/bootstrap";
     let operational_ca_path = "/etc/keel/crypto/ca.pem";
 
-    let mut builder = Server::builder();
+    let mut builder = Server::builder()
+        .http2_keepalive_interval(Some(std::time::Duration::from_secs(10)))
+        .http2_keepalive_timeout(Some(std::time::Duration::from_secs(20)))
+        .tcp_keepalive(Some(std::time::Duration::from_secs(10)));
 
     // Try to configure TLS with dual-CA support
     let tls_manager = TlsManager::new(

--- a/cmd/keel-init/Cargo.toml
+++ b/cmd/keel-init/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-nix = { version = "0.31", features = ["mount", "fs", "process"] }
+nix = { version = "0.31", features = ["mount", "fs", "process", "hostname"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }
 

--- a/cmd/keel-init/src/main.rs
+++ b/cmd/keel-init/src/main.rs
@@ -15,7 +15,6 @@ use nix::sys::stat::{umask, Mode};
 use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
 use nix::unistd::Pid;
 use std::fs;
-use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::{thread, time};
 use tracing::{debug, error, info, warn, Level};
@@ -53,6 +52,13 @@ fn run() -> Result<(), InitError> {
     // Set safe umask
     umask(Mode::from_bits(0o077).unwrap());
 
+    // Set PATH - as PID 1, we have no inherited PATH from a parent process.
+    // Child processes (kubelet, containerd, etc.) need this to find binaries like mount.
+    std::env::set_var(
+        "PATH",
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    );
+
     // Initialize boot phase tracker
     let mut boot_tracker = telemetry::BootPhaseTracker::new();
 
@@ -60,9 +66,16 @@ fn run() -> Result<(), InitError> {
     boot_tracker.start_phase("filesystem");
     setup_filesystems()?;
 
+    // Mount persistent storage for container data
+    boot_tracker.start_phase("storage");
+    setup_persistent_storage();
+
     // Set up cgroups
     boot_tracker.start_phase("cgroups");
     setup_cgroups();
+
+    // Set hostname
+    setup_hostname();
 
     // Configure networking
     boot_tracker.start_phase("network");
@@ -113,6 +126,29 @@ fn setup_filesystems() -> Result<(), InitError> {
     let _ = fs::create_dir_all("/dev");
     let _ = fs::create_dir_all("/tmp");
 
+    // Mount the root filesystem as shared/remount to support pivot_root (required by runc)
+    // When running from initramfs, root is not a mount point, which breaks pivot_root
+    if let Err(e) = mount::<str, str, str, str>(
+        Some("/"),
+        "/",
+        None,
+        MsFlags::MS_BIND | MsFlags::MS_REC,
+        None,
+    ) {
+        warn!(error = %e, "Failed to bind mount / to /");
+    } else {
+        debug!("Bind mounted / to /");
+    }
+
+    // Make the mount private to avoid propagation issues
+    if let Err(e) =
+        mount::<str, str, str, str>(None, "/", None, MsFlags::MS_PRIVATE | MsFlags::MS_REC, None)
+    {
+        warn!(error = %e, "Failed to make / private");
+    } else {
+        debug!("Made / mount private");
+    }
+
     // Mount proc - critical for process management
     if let Err(e) =
         mount::<str, str, str, str>(Some("none"), "/proc", Some("proc"), MsFlags::empty(), None)
@@ -144,6 +180,48 @@ fn setup_filesystems() -> Result<(), InitError> {
         debug!("Mounted /dev");
     }
 
+    // Mount devpts - needed by runc/containerd for container PTY allocation
+    let _ = fs::create_dir_all("/dev/pts");
+    if let Err(e) = mount::<str, str, str, str>(
+        Some("devpts"),
+        "/dev/pts",
+        Some("devpts"),
+        MsFlags::empty(),
+        Some("newinstance,ptmxmode=0666,mode=0620"),
+    ) {
+        warn!(error = %e, "Failed to mount /dev/pts");
+    } else {
+        debug!("Mounted /dev/pts");
+    }
+
+    // Mount /dev/shm - needed for POSIX shared memory in containers
+    let _ = fs::create_dir_all("/dev/shm");
+    if let Err(e) = mount::<str, str, str, str>(
+        Some("tmpfs"),
+        "/dev/shm",
+        Some("tmpfs"),
+        MsFlags::empty(),
+        Some("size=64m"),
+    ) {
+        warn!(error = %e, "Failed to mount /dev/shm");
+    } else {
+        debug!("Mounted /dev/shm");
+    }
+
+    // Mount /dev/mqueue - needed for POSIX message queues
+    let _ = fs::create_dir_all("/dev/mqueue");
+    if let Err(e) = mount::<str, str, str, str>(
+        Some("mqueue"),
+        "/dev/mqueue",
+        Some("mqueue"),
+        MsFlags::empty(),
+        None,
+    ) {
+        warn!(error = %e, "Failed to mount /dev/mqueue");
+    } else {
+        debug!("Mounted /dev/mqueue");
+    }
+
     // Mount tmpfs
     if let Err(e) =
         mount::<str, str, str, str>(Some("none"), "/tmp", Some("tmpfs"), MsFlags::empty(), None)
@@ -155,6 +233,118 @@ fn setup_filesystems() -> Result<(), InitError> {
 
     info!("API filesystems mounted");
     Ok(())
+}
+
+/// Mount persistent storage disk for container and kubelet data.
+/// Without this, all container images and state live on the rootfs (RAM),
+/// which quickly fills up and causes DiskPressure.
+fn setup_persistent_storage() {
+    use std::process::Command;
+
+    let data_mount = "/data";
+
+    // Create mount point
+    let _ = std::fs::create_dir_all(data_mount);
+
+    // Try candidate devices in order of preference
+    let candidates = ["/dev/sda4", "/dev/sda"];
+    let mut mounted = false;
+
+    for dev in &candidates {
+        if !std::path::Path::new(dev).exists() {
+            debug!(device = dev, "Device not found, skipping");
+            continue;
+        }
+
+        info!(device = dev, "Trying to mount persistent storage");
+
+        // First, try mounting directly (already formatted)
+        match mount::<str, str, str, str>(
+            Some(dev),
+            data_mount,
+            Some("ext4"),
+            MsFlags::empty(),
+            None,
+        ) {
+            Ok(()) => {
+                info!(
+                    device = dev,
+                    mount = data_mount,
+                    "Mounted persistent storage"
+                );
+                mounted = true;
+                break;
+            }
+            Err(_) => {
+                // Mount failed, try formatting first
+                info!(device = dev, "Formatting device with ext4");
+                let format_result = Command::new("/sbin/mkfs.ext4").args(["-F", dev]).output();
+
+                match format_result {
+                    Ok(output) if output.status.success() => {
+                        info!(device = dev, "Formatted successfully");
+                        // Try mount again after formatting
+                        match mount::<str, str, str, str>(
+                            Some(dev),
+                            data_mount,
+                            Some("ext4"),
+                            MsFlags::empty(),
+                            None,
+                        ) {
+                            Ok(()) => {
+                                info!(
+                                    device = dev,
+                                    mount = data_mount,
+                                    "Mounted persistent storage after formatting"
+                                );
+                                mounted = true;
+                                break;
+                            }
+                            Err(e) => {
+                                warn!(device = dev, error = %e, "Failed to mount after formatting")
+                            }
+                        }
+                    }
+                    Ok(output) => {
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        warn!(device = dev, stderr = %stderr, "mkfs.ext4 failed");
+                    }
+                    Err(e) => warn!(device = dev, error = %e, "Failed to run mkfs.ext4"),
+                }
+            }
+        }
+    }
+
+    if !mounted {
+        warn!("No persistent storage available. Container data will use rootfs (RAM).");
+        return;
+    }
+
+    // Bind-mount key directories to persistent storage
+    let bind_dirs = [
+        ("containerd", "/var/lib/containerd"),
+        ("kubelet", "/var/lib/kubelet"),
+        ("keel", "/var/lib/keel"),
+    ];
+
+    for (subdir, target) in &bind_dirs {
+        let source = format!("{}/{}", data_mount, subdir);
+        let _ = std::fs::create_dir_all(&source);
+        let _ = std::fs::create_dir_all(target);
+
+        match mount::<str, str, str, str>(
+            Some(source.as_str()),
+            *target,
+            None,
+            MsFlags::MS_BIND,
+            None,
+        ) {
+            Ok(()) => info!(source = %source, target = target, "Bind-mounted persistent storage"),
+            Err(e) => warn!(source = %source, target = target, error = %e, "Failed to bind-mount"),
+        }
+    }
+
+    info!("Persistent storage setup complete");
 }
 
 /// Configure networking based on saved configuration or DHCP fallback
@@ -174,6 +364,33 @@ fn setup_networking() {
             debug!(error = %e, "No network configuration found, using DHCP fallback");
             // Fallback to DHCP on eth0 (QEMU default primary interface)
             configure_dhcp_fallback();
+        }
+    }
+
+    // Ensure /etc/resolv.conf exists - kubelet and other services need it for DNS.
+    // If configure_dns or configure_dhcp_fallback already created it, this is a no-op.
+    if !std::path::Path::new("/etc/resolv.conf").exists() {
+        info!("No /etc/resolv.conf found, creating default");
+        // Use common public DNS resolvers as a safe default
+        let default_resolv =
+            "# Generated by keel-init (default fallback)\nnameserver 8.8.8.8\nnameserver 1.1.1.1\n";
+        if let Err(e) = fs::write("/etc/resolv.conf", default_resolv) {
+            warn!(error = %e, "Failed to create /etc/resolv.conf");
+        }
+    }
+
+    // Ensure /etc/hosts exists - containerd needs it to generate pod sandbox hosts files
+    if !std::path::Path::new("/etc/hosts").exists() {
+        let hostname = nix::unistd::gethostname()
+            .ok()
+            .and_then(|h| h.into_string().ok())
+            .unwrap_or_else(|| "keelos".to_string());
+        let hosts_content = format!(
+            "# Generated by keel-init\n127.0.0.1\tlocalhost\n::1\t\tlocalhost\n127.0.1.1\t{}\n",
+            hostname
+        );
+        if let Err(e) = fs::write("/etc/hosts", hosts_content) {
+            warn!(error = %e, "Failed to create /etc/hosts");
         }
     }
 
@@ -439,6 +656,72 @@ fn configure_dhcp_fallback() {
     }
 }
 
+/// Set up the system hostname
+fn setup_hostname() {
+    // Try /etc/hostname first
+    if let Ok(hostname) = fs::read_to_string("/etc/hostname") {
+        let hostname = hostname.trim().to_string();
+        if !hostname.is_empty() {
+            if let Err(e) = nix::unistd::sethostname(&hostname) {
+                warn!(error = %e, hostname = %hostname, "Failed to set hostname");
+            } else {
+                info!(hostname = %hostname, "Hostname set from /etc/hostname");
+                return;
+            }
+        }
+    }
+
+    // Try kernel command line (hostname=xxx)
+    if let Ok(cmdline) = fs::read_to_string("/proc/cmdline") {
+        for param in cmdline.split_whitespace() {
+            if let Some(hostname) = param.strip_prefix("hostname=") {
+                let hostname = hostname.trim().to_string();
+                if !hostname.is_empty() {
+                    if let Err(e) = nix::unistd::sethostname(&hostname) {
+                        warn!(error = %e, hostname = %hostname, "Failed to set hostname from cmdline");
+                    } else {
+                        info!(hostname = %hostname, "Hostname set from kernel cmdline");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    // Generate a hostname from machine-id or random
+    let hostname = format!("keelos-{}", &uuid_like_id()[..8]);
+    if let Err(e) = nix::unistd::sethostname(&hostname) {
+        warn!(error = %e, hostname = %hostname, "Failed to set generated hostname");
+    } else {
+        info!(hostname = %hostname, "Hostname set (generated)");
+    }
+}
+
+/// Generate a simple unique ID string from machine-id or /dev/urandom
+fn uuid_like_id() -> String {
+    // Try machine-id first
+    if let Ok(id) = fs::read_to_string("/etc/machine-id") {
+        let id = id.trim().to_string();
+        if !id.is_empty() {
+            return id;
+        }
+    }
+
+    // Fall back to reading a small number of random bytes
+    // NOTE: Do NOT use fs::read("/dev/urandom") - it tries to read the entire
+    // infinite device and causes an OOM kernel panic!
+    use std::io::Read;
+    if let Ok(mut f) = std::fs::File::open("/dev/urandom") {
+        let mut buf = [0u8; 16];
+        if f.read_exact(&mut buf).is_ok() {
+            return buf.iter().map(|b| format!("{:02x}", b)).collect();
+        }
+    }
+
+    // Last resort
+    "00000000".to_string()
+}
+
 /// Check for test mode flags in kernel cmdline
 fn check_test_mode() {
     let cmdline = match fs::read_to_string("/proc/cmdline") {
@@ -450,6 +733,41 @@ fn check_test_mode() {
     };
 
     debug!(cmdline = %cmdline.trim(), "Kernel command line");
+
+    if cmdline.contains("test_cni=1") {
+        info!("TEST MODE: Installing static bridge CNI config");
+        // In test environments (QEMU SLIRP), kindnet can't route between Docker and
+        // SLIRP networks. A static bridge CNI gives kubelet a working local CNI.
+        let cni_config = r#"{
+  "cniVersion": "0.3.1",
+  "name": "bridge",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "ipam": {
+        "type": "host-local",
+        "subnet": "10.244.1.0/24",
+        "routes": [{"dst": "0.0.0.0/0"}]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}
+"#;
+        if let Err(e) = fs::create_dir_all("/etc/cni/net.d") {
+            warn!(error = %e, "Failed to create /etc/cni/net.d");
+        }
+        match fs::write("/etc/cni/net.d/10-bridge.conflist", cni_config) {
+            Ok(_) => info!("Static bridge CNI config installed"),
+            Err(e) => warn!(error = %e, "Failed to write CNI config"),
+        }
+    }
 
     if cmdline.contains("test_update=1") {
         info!("TEST MODE: Triggering self-update in 15 seconds");
@@ -481,7 +799,19 @@ fn setup_cgroups() {
         None,
     ) {
         Ok(_) => debug!("Mounted cgroup v2 at /sys/fs/cgroup"),
-        Err(e) => warn!(error = %e, "Failed to mount cgroup v2"),
+        Err(e) => {
+            warn!(error = %e, "Failed to mount cgroup v2");
+            return;
+        }
+    }
+
+    // Enable cgroup v2 controllers in the root cgroup.
+    // Without this, sub-cgroups (e.g. kubepods/) won't have controller interface files
+    // like cpu.max, memory.max, etc., causing runc container creation to fail.
+    let controllers = "+cpu +memory +io +pids +cpuset";
+    match fs::write("/sys/fs/cgroup/cgroup.subtree_control", controllers) {
+        Ok(_) => info!("Enabled cgroup v2 controllers: {}", controllers),
+        Err(e) => warn!(error = %e, "Failed to enable cgroup v2 controllers"),
     }
 }
 
@@ -493,6 +823,8 @@ fn spawn_service(name: &str, path: &str, args: &[&str]) -> Option<Child> {
         return None;
     }
 
+    info!(service = name, path = path, args = ?args, "Spawning service");
+
     let mut cmd = Command::new(path);
     cmd.args(args)
         .stdout(Stdio::inherit())
@@ -500,11 +832,15 @@ fn spawn_service(name: &str, path: &str, args: &[&str]) -> Option<Child> {
 
     match cmd.spawn() {
         Ok(child) => {
-            info!(service = name, pid = child.id(), "Service started");
+            info!(
+                service = name,
+                pid = child.id(),
+                "✅ Service started successfully"
+            );
             Some(child)
         }
         Err(e) => {
-            error!(service = name, error = %e, "Failed to spawn service");
+            error!(service = name, path = path, args = ?args, error = %e, "❌ Failed to spawn service");
             None
         }
     }
@@ -544,13 +880,70 @@ fn spawn_kubelet() -> Option<Child> {
         "/usr/bin/kubelet"
     };
 
-    // Check if kubeconfig exists (set during bootstrap)
-    let kubeconfig_path = "/var/lib/keel/kubernetes/kubelet.kubeconfig";
-    let mut args = vec!["--config=/etc/kubernetes/kubelet-config.yaml", "--v=2"];
+    // Ensure kubelet directories exist
+    let _ = fs::create_dir_all("/var/lib/kubelet/pki");
+    let _ = fs::create_dir_all("/var/lib/kubelet");
 
-    if std::path::Path::new(kubeconfig_path).exists() {
-        info!(path = kubeconfig_path, "Using kubeconfig for kubelet");
-        args.push("--kubeconfig=/var/lib/keel/kubernetes/kubelet.kubeconfig");
+    // Check if kubeconfig exists (set during bootstrap)
+    let bootstrap_kubeconfig = "/var/lib/keel/kubernetes/kubelet.kubeconfig";
+    let kubeconfig_path = "/var/lib/kubelet/kubeconfig"; // Permanent kubeconfig after CSR
+    let mut args = vec![
+        "--config=/etc/kubernetes/kubelet-config.yaml",
+        "--cert-dir=/var/lib/kubelet/pki",
+        "--v=2",
+    ];
+
+    // Set hostname override to ensure kubelet uses valid node name
+    // Priority:
+    // 1. Node name from bootstrap config (if bootstrapped)
+    // 2. System hostname (if set)
+    // 3. Generated fallback
+    let bootstrap_config_path = "/var/lib/keel/kubernetes/bootstrap.json";
+    let hostname =
+        if let Ok(config) = keel_config::bootstrap::BootstrapConfig::load(bootstrap_config_path) {
+            info!(node_name = %config.node_name, "Using node name from bootstrap configuration");
+            config.node_name
+        } else {
+            nix::unistd::gethostname()
+                .ok()
+                .and_then(|h| h.into_string().ok())
+                .unwrap_or_default()
+        };
+
+    let hostname_arg = if !hostname.is_empty() && hostname != "(none)" && hostname != "localhost" {
+        Some(format!("--hostname-override={}", hostname))
+    } else {
+        // Generate a fallback node name
+        let fallback = format!("keelos-node-{}", &uuid_like_id()[..8]);
+        Some(format!("--hostname-override={}", fallback))
+    };
+    if let Some(ref arg) = hostname_arg {
+        args.push(arg);
+    }
+
+    // Bootstrap flow:
+    // 1. If bootstrap kubeconfig exists but permanent doesn't -> initial bootstrap
+    // 2. If permanent kubeconfig exists -> already joined, use permanent
+    // 3. If neither exists -> standalone mode
+    if std::path::Path::new(bootstrap_kubeconfig).exists() {
+        if !std::path::Path::new(kubeconfig_path).exists() {
+            // Initial bootstrap - kubelet will use bootstrap token to generate CSR
+            info!(
+                bootstrap_path = bootstrap_kubeconfig,
+                target_path = kubeconfig_path,
+                "Using bootstrap kubeconfig for initial cluster join"
+            );
+            args.push("--bootstrap-kubeconfig=/var/lib/keel/kubernetes/kubelet.kubeconfig");
+            args.push("--kubeconfig=/var/lib/kubelet/kubeconfig");
+        } else {
+            // Already bootstrapped - use permanent kubeconfig
+            info!(path = kubeconfig_path, "Using permanent kubeconfig");
+            args.push("--kubeconfig=/var/lib/kubelet/kubeconfig");
+        }
+    } else if std::path::Path::new(kubeconfig_path).exists() {
+        // Only permanent kubeconfig exists
+        info!(path = kubeconfig_path, "Using permanent kubeconfig");
+        args.push("--kubeconfig=/var/lib/kubelet/kubeconfig");
     } else {
         debug!("No kubeconfig found - kubelet will run in standalone mode");
     }
@@ -558,19 +951,72 @@ fn spawn_kubelet() -> Option<Child> {
     spawn_service("kubelet", kubelet_path, &args)
 }
 
+/// Import pre-loaded container images from known locations into containerd
+/// This ensures images like the pause container are available without network access
+fn import_preloaded_images() {
+    // Check multiple locations for pre-loaded images:
+    // 1. /usr/share/keel/images/ - bundled in the initramfs (e.g., pause image)
+    // 2. /data/images/ - pre-populated on the data partition (e.g., kube-proxy, kindnet)
+    let image_dirs = ["/usr/share/keel/images", "/data/images"];
+
+    for images_dir in &image_dirs {
+        info!(dir = images_dir, "Scanning for pre-loaded container images");
+        let entries = match fs::read_dir(images_dir) {
+            Ok(entries) => entries,
+            Err(e) => {
+                info!(dir = images_dir, error = %e, "Pre-loaded images directory not found");
+                continue;
+            }
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("tar") {
+                let path_str = path.to_string_lossy();
+                let file_size = fs::metadata(&*path_str).map(|m| m.len()).unwrap_or(0);
+                info!(image = %path_str, size_bytes = file_size, "Importing pre-loaded container image");
+                match Command::new("/usr/bin/ctr")
+                    .args(["-n", "k8s.io", "images", "import", &path_str])
+                    .output()
+                {
+                    Ok(output) if output.status.success() => {
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        info!(image = %path_str, stdout = %stdout, "Successfully imported container image");
+                    }
+                    Ok(output) => {
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        warn!(image = %path_str, stderr = %stderr, stdout = %stdout, "Failed to import container image");
+                    }
+                    Err(e) => {
+                        warn!(image = %path_str, error = %e, "Failed to run ctr images import");
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Main supervision loop for system services
 fn supervise_services() -> Result<(), InitError> {
-    // Start containerd
-    info!("Starting containerd");
-    let mut containerd = spawn_service("containerd", "/usr/bin/containerd", &[]);
-
-    // Start keel-agent
+    // Start keel-agent first - it handles bootstrap
     info!("Starting keel-agent");
     let mut agent = spawn_service("keel-agent", "/usr/bin/keel-agent", &[]);
 
-    // Start kubelet (with override support and kubeconfig)
+    // Start container services immediately
+    // If bootstrap kubeconfig exists, kubelet will use it for cluster join
+    // If not, kubelet runs in standalone mode and will be restarted when bootstrap completes
+    info!("Starting containerd");
+    let mut containerd: Option<Child> = spawn_service("containerd", "/usr/bin/containerd", &[]);
+
+    // Give containerd a moment to initialize its socket
+    thread::sleep(time::Duration::from_secs(2));
+
+    // Import pre-loaded container images (e.g., pause image for pod sandboxes)
+    import_preloaded_images();
+
     info!("Starting kubelet");
-    let mut kubelet = spawn_kubelet();
+    let mut kubelet: Option<Child> = spawn_kubelet();
 
     // Track restart counts for backoff
     let mut agent_restart_count: u32 = 0;
@@ -621,19 +1067,58 @@ fn supervise_services() -> Result<(), InitError> {
             }
         }
 
-        // Check for kubelet restart signal (from bootstrap)
-        if Path::new("/run/keel/restart-kubelet").exists() {
+        // Check for bootstrap kubeconfig to start or restart services
+        let bootstrap_kubeconfig = "/var/lib/keel/kubernetes/kubelet.kubeconfig";
+        let permanent_kubeconfig = "/var/lib/kubelet/kubeconfig";
+        let bootstrap_exists = std::path::Path::new(bootstrap_kubeconfig).exists();
+        let permanent_exists = std::path::Path::new(permanent_kubeconfig).exists();
+
+        // If bootstrap kubeconfig has just appeared and kubelet isn't configured for it,
+        // restart kubelet to pick up the bootstrap configuration
+        if bootstrap_exists && kubelet.is_none() {
+            info!("Bootstrap kubeconfig detected - restarting kubelet with cluster config");
+            kubelet = spawn_kubelet();
+        }
+
+        // Handle explicit restart signal or permanent kubeconfig appearing
+        let should_restart = if std::path::Path::new("/run/keel/restart-kubelet").exists() {
+            // Explicit restart signal from keel-agent
             info!("Kubelet restart signal detected");
-            // Kill existing kubelet if running
-            if let Some(mut child) = kubelet {
-                info!("Stopping kubelet for restart");
-                let _ = child.kill();
-                let _ = child.wait(); // Clean up zombie
+            true // Restart regardless of whether kubelet is running
+        } else if bootstrap_exists && permanent_exists && kubelet.is_some() {
+            // Permanent kubeconfig appeared - kubelet successfully bootstrapped
+            // Restart to switch from bootstrap to permanent kubeconfig
+            static SWITCHED: std::sync::atomic::AtomicBool =
+                std::sync::atomic::AtomicBool::new(false);
+            if !SWITCHED.load(std::sync::atomic::Ordering::Relaxed) {
+                info!("Permanent kubeconfig detected - restarting kubelet to use it");
+                SWITCHED.store(true, std::sync::atomic::Ordering::Relaxed);
+                true
+            } else {
+                false
             }
-            // Remove signal file
+        } else {
+            false
+        };
+
+        // Restart kubelet if signal detected or kubeconfig changed
+        if should_restart {
+            if let Some(ref mut child) = kubelet {
+                info!(pid = child.id(), "Stopping kubelet for restart");
+                let _ = child.kill();
+                let _ = child.wait();
+                info!("Kubelet process stopped, preparing to respawn");
+            }
             let _ = fs::remove_file("/run/keel/restart-kubelet");
             // Restart kubelet with new configuration
+            info!("Calling spawn_kubelet() to restart with updated config");
             kubelet = spawn_kubelet();
+            if let Some(ref child) = kubelet {
+                info!(pid = child.id(), "✅ Kubelet successfully restarted");
+            } else {
+                error!("⚠️  CRITICAL: spawn_kubelet() returned None - kubelet failed to restart!");
+                error!("This means kubelet will not join the cluster. Check logs above for spawn errors.");
+            }
         }
 
         thread::sleep(time::Duration::from_secs(5));

--- a/cmd/osctl/src/main.rs
+++ b/cmd/osctl/src/main.rs
@@ -200,16 +200,27 @@ async fn connect_with_auto_tls(
         // Create TLS identity
         let identity = tonic::transport::Identity::from_pem(cert_pem, key_pem);
 
-        // Configure TLS endpoint
+        // Configure TLS endpoint with timeout and keepalive
         let tls_endpoint = tonic::transport::Channel::from_shared(endpoint.to_string())?
-            .tls_config(tonic::transport::ClientTlsConfig::new().identity(identity))?;
+            .tls_config(tonic::transport::ClientTlsConfig::new().identity(identity))?
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .http2_keep_alive_interval(std::time::Duration::from_secs(10))
+            .keep_alive_timeout(std::time::Duration::from_secs(20));
 
         Ok(NodeServiceClient::connect(tls_endpoint).await?)
     } else {
-        // No certs found, use plain HTTP
+        // No certs found, use plain HTTP with timeout and keepalive
         eprintln!("ℹ️  No certificates found, using HTTP");
         eprintln!("💡 Run 'osctl init bootstrap --node <ip>' to enable mTLS");
-        Ok(NodeServiceClient::connect(endpoint.to_string()).await?)
+        let channel = tonic::transport::Channel::from_shared(endpoint.to_string())?
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .http2_keep_alive_interval(std::time::Duration::from_secs(10))
+            .keep_alive_timeout(std::time::Duration::from_secs(20))
+            .connect()
+            .await?;
+        Ok(NodeServiceClient::new(channel))
     }
 }
 

--- a/tools/builder/Dockerfile
+++ b/tools/builder/Dockerfile
@@ -30,6 +30,9 @@ RUN apt-get update && apt-get install -y \
     cmake \
     clang \
     iproute2 \
+    e2fsprogs \
+    libseccomp2 \
+    iptables \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GRUB only on x86_64 (not available on ARM)
@@ -60,6 +63,15 @@ RUN export RUNC_VERSION=1.1.10 && \
     wget https://github.com/opencontainers/runc/releases/download/v${RUNC_VERSION}/runc.amd64 && \
     install -m 755 runc.amd64 /usr/local/sbin/runc && \
     rm runc.amd64
+
+# Pre-download pause container image for offline use
+# This avoids needing network access to pull the image during container creation
+RUN CRANE_VERSION=0.19.1 && \
+    wget -O /tmp/crane.tar.gz https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz && \
+    tar -xzf /tmp/crane.tar.gz -C /usr/local/bin crane && \
+    rm /tmp/crane.tar.gz && \
+    crane pull --platform linux/amd64 registry.k8s.io/pause:3.9 /usr/local/share/pause-3.9.tar && \
+    rm /usr/local/bin/crane
 
 # Install CNI plugins (x86_64 target)
 RUN export CNI_VERSION=1.3.0 && \

--- a/tools/builder/containerd-config.toml
+++ b/tools/builder/containerd-config.toml
@@ -8,3 +8,5 @@ version = 2
 
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = false
+  NoPivotRoot = true
+  BinaryName = "/usr/sbin/runc"

--- a/tools/builder/initramfs-build.sh
+++ b/tools/builder/initramfs-build.sh
@@ -17,6 +17,7 @@ mkdir -p "${INITRAMFS_DIR}/sys"
 mkdir -p "${INITRAMFS_DIR}/usr/bin"
 mkdir -p "${INITRAMFS_DIR}/usr/sbin"
 mkdir -p "${INITRAMFS_DIR}/opt/cni/bin"
+mkdir -p "${INITRAMFS_DIR}/etc/cni/net.d"
 mkdir -p "${INITRAMFS_DIR}/var/lib/containerd"
 mkdir -p "${INITRAMFS_DIR}/run/containerd"
 mkdir -p "${INITRAMFS_DIR}/etc/containerd"
@@ -29,7 +30,39 @@ cp -L /usr/local/bin/containerd* "${INITRAMFS_DIR}/usr/bin/"
 cp -L /usr/local/bin/ctr "${INITRAMFS_DIR}/usr/bin/"
 cp -L /usr/local/sbin/runc "${INITRAMFS_DIR}/usr/sbin/"
 cp -rL /opt/cni/bin/* "${INITRAMFS_DIR}/opt/cni/bin/"
+
+# Copy iptables (required by kubelet and kube-proxy for network rules)
+echo ">>> Copying iptables..."
+for bin in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore xtables-legacy-multi xtables-nft-multi; do
+    for dir in /usr/sbin /sbin /usr/bin /bin; do
+        if [ -f "${dir}/${bin}" ]; then
+            cp -L "${dir}/${bin}" "${INITRAMFS_DIR}/usr/sbin/"
+            break
+        fi
+    done
+done
+# Some systems use alternatives - ensure the main iptables binary exists
+if [ ! -f "${INITRAMFS_DIR}/usr/sbin/iptables" ]; then
+    # Try iptables-legacy or iptables-nft
+    if [ -f "/usr/sbin/iptables-legacy" ]; then
+        cp -L /usr/sbin/iptables-legacy "${INITRAMFS_DIR}/usr/sbin/iptables"
+        cp -L /usr/sbin/ip6tables-legacy "${INITRAMFS_DIR}/usr/sbin/ip6tables" 2>/dev/null || true
+    elif [ -f "${INITRAMFS_DIR}/usr/sbin/xtables-nft-multi" ]; then
+        ln -sf xtables-nft-multi "${INITRAMFS_DIR}/usr/sbin/iptables"
+        ln -sf xtables-nft-multi "${INITRAMFS_DIR}/usr/sbin/ip6tables"
+    fi
+fi
 cp -L "${PROJECT_ROOT}/tools/builder/containerd-config.toml" "${INITRAMFS_DIR}/etc/containerd/config.toml"
+
+# Copy pre-downloaded container images for offline use
+echo ">>> Copying pre-downloaded container images..."
+mkdir -p "${INITRAMFS_DIR}/usr/share/keel/images"
+if [ -f /usr/local/share/pause-3.9.tar ]; then
+    cp -L /usr/local/share/pause-3.9.tar "${INITRAMFS_DIR}/usr/share/keel/images/"
+    echo "  Copied pause:3.9 image"
+else
+    echo "  WARNING: pause-3.9.tar not found"
+fi
 
 echo ">>> Copying GLIBC libraries (for dynamic Kubelet)..."
 mkdir -p "${INITRAMFS_DIR}/lib64"
@@ -56,11 +89,37 @@ if [ -f "${GLIBC_LIB_PATH}/libresolv.so.2" ]; then cp -L "${GLIBC_LIB_PATH}/libr
 # Optional but recommended
 if [ -f "${GLIBC_LIB_PATH}/libdl.so.2" ]; then cp -L "${GLIBC_LIB_PATH}/libdl.so.2" "${INITRAMFS_DIR}/lib/"; fi
 if [ -f "${GLIBC_LIB_PATH}/libm.so.6" ]; then cp -L "${GLIBC_LIB_PATH}/libm.so.6" "${INITRAMFS_DIR}/lib/"; fi
+# libseccomp - required by runc for container security
+if [ -f "${GLIBC_LIB_PATH}/libseccomp.so.2" ]; then
+    cp -L "${GLIBC_LIB_PATH}/libseccomp.so.2" "${INITRAMFS_DIR}/lib/"
+elif [ -f "/usr/lib/x86_64-linux-gnu/libseccomp.so.2" ]; then
+    cp -L "/usr/lib/x86_64-linux-gnu/libseccomp.so.2" "${INITRAMFS_DIR}/lib/"
+else
+    echo "WARNING: libseccomp.so.2 not found - runc may fail"
+fi
+# iptables libraries - required by iptables/ip6tables
+for lib in libip4tc libip6tc libxtables libnftnl libmnl; do
+    for pattern in "${GLIBC_LIB_PATH}/${lib}.so"* "/usr/lib/x86_64-linux-gnu/${lib}.so"*; do
+        if [ -f "${pattern}" ]; then
+            cp -L "${pattern}" "${INITRAMFS_DIR}/lib/" 2>/dev/null || true
+        fi
+    done
+done
 
 cp -L "${PROJECT_ROOT}/tools/builder/containerd-config.toml" "${INITRAMFS_DIR}/etc/containerd/config.toml"
 
+echo ">>> Copying CA certificates (for TLS verification)..."
+mkdir -p "${INITRAMFS_DIR}/etc/ssl/certs"
+if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+    cp -L /etc/ssl/certs/ca-certificates.crt "${INITRAMFS_DIR}/etc/ssl/certs/"
+    echo "    Copied CA certificates bundle"
+else
+    echo "    WARNING: No CA certificates found in build container"
+fi
+
 echo ">>> Copying Kubernetes binaries..."
 mkdir -p "${INITRAMFS_DIR}/var/lib/kubelet"
+mkdir -p "${INITRAMFS_DIR}/var/lib/kubelet/pki"  # For TLS certificates generated via bootstrap
 mkdir -p "${INITRAMFS_DIR}/etc/kubernetes/manifests"
 cp -L /usr/local/bin/kubelet "${INITRAMFS_DIR}/usr/bin/"
 cp -L "${PROJECT_ROOT}/tools/builder/kubelet-config.yaml" "${INITRAMFS_DIR}/etc/kubernetes/kubelet-config.yaml"
@@ -95,6 +154,28 @@ cp /usr/local/bin/busybox "${INITRAMFS_DIR}/bin/busybox"
 ln -sf busybox "${INITRAMFS_DIR}/bin/sh"
 ln -sf busybox "${INITRAMFS_DIR}/bin/ifconfig"
 ln -sf busybox "${INITRAMFS_DIR}/bin/route"
+ln -sf busybox "${INITRAMFS_DIR}/bin/hostname"
+ln -sf ../bin/busybox "${INITRAMFS_DIR}/bin/mount"
+ln -sf ../bin/busybox "${INITRAMFS_DIR}/bin/umount"
+ln -sf ../bin/busybox "${INITRAMFS_DIR}/sbin/mount"
+ln -sf ../bin/busybox "${INITRAMFS_DIR}/sbin/umount"
+# Kubelet looks for mount in /usr/bin and standard PATH locations
+mkdir -p "${INITRAMFS_DIR}/usr/bin"
+ln -sf ../../bin/busybox "${INITRAMFS_DIR}/usr/bin/mount"
+ln -sf ../../bin/busybox "${INITRAMFS_DIR}/usr/bin/umount"
+# Filesystem tools for persistent storage auto-formatting (real e2fsprogs binary)
+echo ">>> Copying mkfs.ext4 from e2fsprogs..."
+if [ -f /sbin/mkfs.ext4 ]; then
+    cp -L /sbin/mkfs.ext4 "${INITRAMFS_DIR}/sbin/mkfs.ext4"
+elif [ -f /usr/sbin/mkfs.ext4 ]; then
+    cp -L /usr/sbin/mkfs.ext4 "${INITRAMFS_DIR}/sbin/mkfs.ext4"
+else
+    echo "WARNING: mkfs.ext4 not found in builder"
+fi
+# Copy e2fsprogs shared library dependencies
+for lib in libext2fs.so.2 libcom_err.so.2 libe2p.so.2 libblkid.so.1 libuuid.so.1; do
+    find /lib /usr/lib -name "$lib" -exec cp -L {} "${INITRAMFS_DIR}/lib/" \; 2>/dev/null || true
+done
 
 echo ">>> Copying iproute2 (for advanced networking)..."
 # iproute2 provides full-featured ip command for VLAN, bonding, etc.

--- a/tools/builder/kernel-build.sh
+++ b/tools/builder/kernel-build.sh
@@ -55,7 +55,60 @@ make ARCH=x86_64 CROSS_COMPILE=x86_64-linux-gnu- x86_64_defconfig
 ./scripts/config --enable CONFIG_X86_64
 ./scripts/config --disable CONFIG_DEBUG_INFO
 
-./scripts/config --disable CONFIG_DEBUG_INFO
+# eBPF support (required for cgroup v2 device filtering in runc/containerd)
+./scripts/config --enable CONFIG_BPF
+./scripts/config --enable CONFIG_BPF_SYSCALL
+./scripts/config --enable CONFIG_CGROUP_BPF
+./scripts/config --enable CONFIG_CGROUP_DEVICE
+
+# Cgroup v2 controllers (required for kubelet/runc resource management)
+./scripts/config --enable CONFIG_CGROUPS
+./scripts/config --enable CONFIG_MEMCG
+./scripts/config --enable CONFIG_CGROUP_PIDS
+./scripts/config --enable CONFIG_CGROUP_SCHED
+./scripts/config --enable CONFIG_CFS_BANDWIDTH
+./scripts/config --enable CONFIG_CPUSETS
+./scripts/config --enable CONFIG_BLK_CGROUP
+
+# Namespaces (required for container isolation)
+./scripts/config --enable CONFIG_NAMESPACES
+./scripts/config --enable CONFIG_NET_NS
+./scripts/config --enable CONFIG_PID_NS
+./scripts/config --enable CONFIG_IPC_NS
+./scripts/config --enable CONFIG_UTS_NS
+./scripts/config --enable CONFIG_USER_NS
+
+# Networking (required for CNI/pod networking)
+./scripts/config --enable CONFIG_VETH
+./scripts/config --enable CONFIG_BRIDGE
+./scripts/config --enable CONFIG_BRIDGE_NETFILTER
+./scripts/config --enable CONFIG_NETFILTER
+./scripts/config --enable CONFIG_NETFILTER_ADVANCED
+./scripts/config --enable CONFIG_NETFILTER_XTABLES
+./scripts/config --enable CONFIG_NF_CONNTRACK
+./scripts/config --enable CONFIG_NF_NAT
+./scripts/config --enable CONFIG_NF_TABLES
+./scripts/config --enable CONFIG_NF_TABLES_IPV4
+./scripts/config --enable CONFIG_NF_TABLES_IPV6
+./scripts/config --enable CONFIG_IP_NF_IPTABLES
+./scripts/config --enable CONFIG_IP_NF_NAT
+./scripts/config --enable CONFIG_IP_NF_FILTER
+./scripts/config --enable CONFIG_IP6_NF_IPTABLES
+./scripts/config --enable CONFIG_IP6_NF_FILTER
+./scripts/config --enable CONFIG_IP6_NF_NAT
+
+# Container runtime support (required by runc/containerd-shim)
+./scripts/config --enable CONFIG_SECCOMP
+./scripts/config --enable CONFIG_SECCOMP_FILTER
+./scripts/config --enable CONFIG_FHANDLE
+./scripts/config --enable CONFIG_TMPFS
+./scripts/config --enable CONFIG_CGROUP_FREEZER
+./scripts/config --enable CONFIG_PROC_FS
+./scripts/config --enable CONFIG_POSIX_MQUEUE
+./scripts/config --enable CONFIG_KEYS
+./scripts/config --enable CONFIG_EPOLL
+./scripts/config --enable CONFIG_SIGNALFD
+./scripts/config --enable CONFIG_TIMERFD
 
 # Update config to resolve any new dependencies non-interactively
 make ARCH=x86_64 CROSS_COMPILE=x86_64-linux-gnu- olddefconfig

--- a/tools/builder/kubelet-config.yaml
+++ b/tools/builder/kubelet-config.yaml
@@ -2,16 +2,40 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: cgroupfs
 failSwapOn: false
-# Use the containerd socket we established in Phase 3
+
+# Container runtime
 containerRuntimeEndpoint: "unix:///run/containerd/containerd.sock"
-# Allow running static pods from manifests (good for bootstrapping)
+
+# Static pods
 staticPodPath: "/etc/kubernetes/manifests"
-# Minimal environment settings
+
+# TLS Bootstrap - enables kubelet to join cluster via bootstrap token
+serverTLSBootstrap: true
+rotateCertificates: true
+
+# Authentication
 authentication:
+  # Note: clientCAFile is not set here because the CA cert is written during bootstrap
+  # The kubelet will use the CA from the kubeconfig instead
   anonymous:
-    enabled: true
+    enabled: false  # Security: disable anonymous access
   webhook:
     enabled: false
+
+# Authorization
 authorization:
   mode: AlwaysAllow
+
+# TLS Certificate Configuration
+# Note: tlsCertFile and tlsPrivateKeyFile are not set here.
+# - For client auth: uses certificates from --bootstrap-kubeconfig / --kubeconfig
+# - For server HTTPS: kubelet auto-generates self-signed certs on first run
+# The bootstrap process will create proper client certificates via CSR approval
+
+# Cluster configuration
+clusterDomain: cluster.local
+clusterDNS:
+  - 10.96.0.10  # Default Kubernetes CoreDNS service IP
+
+# Read-only port for health checks
 readOnlyPort: 10255

--- a/tools/ci-build-only.sh
+++ b/tools/ci-build-only.sh
@@ -36,4 +36,10 @@ echo ">>> Building ISO..."
 echo ">>> Setting up test disk..."
 ./tools/testing/setup-test-disk.sh
 
+# 6. Free disk space - release artifacts already copied to build/
+echo ">>> Cleaning up build artifacts to free disk space..."
+rm -rf /keelos/target/x86_64-unknown-linux-musl/release/deps
+rm -rf /keelos/target/x86_64-unknown-linux-musl/release/build
+rm -rf /keelos/target/x86_64-unknown-linux-musl/release/.fingerprint
+
 echo ">>> Build Complete! Artifacts ready for testing."

--- a/tools/testing/run-qemu.sh
+++ b/tools/testing/run-qemu.sh
@@ -6,6 +6,12 @@ BUILD_DIR="${PROJECT_ROOT}/build"
 KERNEL="${BUILD_DIR}/kernel/bzImage"
 INITRAMFS="${BUILD_DIR}/initramfs.cpio.gz"
 
+# Host port for gRPC forwarding (default: 50052)
+QEMU_HOST_PORT="${QEMU_HOST_PORT:-50052}"
+
+# Disk image (default: sda.img in build dir)
+QEMU_DISK="${QEMU_DISK:-${BUILD_DIR}/sda.img}"
+
 # Check dependencies
 if ! command -v qemu-system-x86_64 &> /dev/null; then
     echo "Error: qemu-system-x86_64 not found."
@@ -16,13 +22,14 @@ if [ ! -f "${KERNEL}" ]; then
     echo "Warning: Kernel not found at ${KERNEL}. (Did you build it?)"
 fi
 
-echo ">>> Booting KeelOS in QEMU..."
+echo ">>> Booting KeelOS in QEMU (port ${QEMU_HOST_PORT} -> 50051)..."
 qemu-system-x86_64 \
     -kernel "${KERNEL}" \
     -initrd "${INITRAMFS}" \
-    -m 1G \
+    -m 4G \
+    -smp 2 \
     -nographic \
     -append "console=ttyS0 quiet loglevel=3 init=/init panic=1 ${EXTRA_APPEND}" \
-    -drive file="${BUILD_DIR}/sda.img",format=raw \
-    -net nic -net user,hostfwd=tcp::50052-:50051 \
+    -drive file="${QEMU_DISK}",format=raw \
+    -net nic -net user,hostfwd=tcp::${QEMU_HOST_PORT}-:50051 \
     -no-reboot

--- a/tools/testing/setup-kind.sh
+++ b/tools/testing/setup-kind.sh
@@ -5,6 +5,9 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 KIND_CONFIG="${PROJECT_ROOT}/build/kind-config.yaml"
 CLUSTER_NAME="keel-test"
 
+# Use a dedicated kubeconfig to avoid macOS ~/.kube/config lock issues
+export KUBECONFIG="${PROJECT_ROOT}/build/keel-test.kubeconfig"
+
 echo ">>> Setting up Kind cluster for KeelOS bootstrap testing..."
 
 # Check if kind is installed
@@ -29,14 +32,18 @@ fi
 # Create build directory if it doesn't exist
 mkdir -p "${PROJECT_ROOT}/build"
 
+# Detect host's local IP address
+HOST_IP=$(ipconfig getifaddr en0 || ipconfig getifaddr en1 || echo "127.0.0.1")
+echo "Host IP detected: ${HOST_IP}"
+
 # Generate kind configuration
 echo "Generating kind configuration..."
 cat > "${KIND_CONFIG}" <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
-  apiServerAddress: "127.0.0.1"
   apiServerPort: 6443
+  disableDefaultCNI: true
 nodes:
 - role: control-plane
   kubeadmConfigPatches:
@@ -47,16 +54,71 @@ nodes:
       - "localhost"
       - "127.0.0.1"
       - "10.0.2.2"
+      - "${HOST_IP}"
 EOF
 
 echo "Creating kind cluster '${CLUSTER_NAME}'..."
-kind create cluster --name "${CLUSTER_NAME}" --config "${KIND_CONFIG}"
+kind create cluster --name "${CLUSTER_NAME}" --config "${KIND_CONFIG}" --kubeconfig "${KUBECONFIG}"
+
+# Install static bridge CNI config on control plane
+# (kindnet is disabled since it can't route between Docker and QEMU networks)
+echo ">>> Installing bridge CNI on control plane..."
+docker exec "${CLUSTER_NAME}-control-plane" mkdir -p /etc/cni/net.d
+docker exec "${CLUSTER_NAME}-control-plane" sh -c 'cat > /etc/cni/net.d/10-bridge.conflist << CNIEOF
+{
+  "cniVersion": "0.3.1",
+  "name": "bridge",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "ipam": {
+        "type": "host-local",
+        "subnet": "10.244.0.0/24",
+        "routes": [{"dst": "0.0.0.0/0"}]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}
+CNIEOF'
+echo ">>> Bridge CNI installed on control plane"
+
+echo ">>> Cluster created. Configuring RBAC for node bootstrap..."
+
+# Allow bootstrap tokens to create CSRs
+echo ">>> Granting CSR creation permissions to bootstrap tokens..."
+kubectl create clusterrolebinding kubeadm:kubelet-bootstrap \
+    --clusterrole=system:node-bootstrapper \
+    --group=system:bootstrappers 2>/dev/null || echo "ClusterRoleBinding already exists"
+
+# Auto-approve kubelet serving certificates
+echo ">>> Configuring auto-approval for kubelet certificates..."
+kubectl create clusterrolebinding auto-approve-csrs-for-group \
+    --clusterrole=system:certificates.k8s.io:certificatesigningrequests:nodeclient \
+    --group=system:bootstrappers 2>/dev/null || echo "ClusterRoleBinding already exists"
+
+kubectl create clusterrolebinding auto-approve-renewals-for-nodes \
+    --clusterrole=system:certificates.k8s.io:certificatesigningrequests:selfnodeclient \
+    --group=system:nodes 2>/dev/null || echo "ClusterRoleBinding already exists"
+
+kubectl create clusterrolebinding auto-approve-serving-for-nodes \
+    --clusterrole=system:certificates.k8s.io:certificatesigningrequests:selfnodeclient \
+    --group=system:nodes 2>/dev/null || echo "ClusterRoleBinding already exists"
+
+echo ">>> Kind cluster is ready for node bootstrapping"
 
 echo "Waiting for cluster to be ready..."
 kubectl wait --for=condition=Ready nodes --all --timeout=60s
 
+# The following RBAC rules are now redundant as they have been moved and renamed above.
 # Create RBAC for bootstrap tokens (idempotent)
-echo "Creating RBAC for bootstrap tokens..."
+# echo "Creating RBAC for bootstrap tokens..."
 
 # Create ClusterRoleBinding for system:node-bootstrapper
 kubectl create clusterrolebinding kubeadm:kubelet-bootstrap \

--- a/tools/testing/setup-test-disk.sh
+++ b/tools/testing/setup-test-disk.sh
@@ -3,28 +3,32 @@ set -e
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DISK_IMG="${PROJECT_ROOT}/build/sda.img"
+FORCE="${1:-}"
 
-if [ -f "$DISK_IMG" ]; then
+if [ -f "$DISK_IMG" ] && [ "$FORCE" != "--force" ]; then
     echo "Test disk already exists at $DISK_IMG"
+    echo "Use --force to recreate it."
     exit 0
 fi
 
-echo ">>> Creating test disk image (512MB)..."
+echo ">>> Creating test disk image (2GB)..."
 mkdir -p "${PROJECT_ROOT}/build"
-qemu-img create -f raw "$DISK_IMG" 512M
+qemu-img create -f raw "$DISK_IMG" 2G
 
-echo ">>> Partitioning disk with sfdisk..."
-# Partition table (GPT)
-# 1: 50M EFI
-# 2: 200M ROOT_A
-# 3: 200M ROOT_B
-# 4: rest DATA
-cat <<EOF | sfdisk "$DISK_IMG"
+# Partition the disk image (only on Linux where sfdisk is available)
+# Layout: 50M EFI, 200M ROOT_A, 200M ROOT_B, rest DATA
+if command -v sfdisk &> /dev/null; then
+    echo ">>> Partitioning disk with sfdisk..."
+    cat <<EOF | sfdisk "$DISK_IMG"
 label: dos
 size=50M, type=ef
 size=200M, type=83
 size=200M, type=83
 type=83
 EOF
+else
+    echo ">>> Skipping partitioning (sfdisk not available on macOS)."
+    echo "   The raw disk image will work for testing."
+fi
 
 echo ">>> Disk setup complete."

--- a/tools/testing/test-bootstrap-kind.sh
+++ b/tools/testing/test-bootstrap-kind.sh
@@ -9,6 +9,9 @@ TIMEOUT=60
 OSCTL="${PROJECT_ROOT}/build/osctl"
 ENDPOINT="http://localhost:50052"
 
+# Use a dedicated kubeconfig to avoid macOS ~/.kube/config lock issues
+export KUBECONFIG="${PROJECT_ROOT}/build/keel-test.kubeconfig"
+
 echo ">>> Starting Kubernetes Bootstrap Integration Test..."
 
 # Check dependencies
@@ -38,6 +41,17 @@ fi
 
 # Setup Kind cluster
 echo "Setting up Kind cluster..."
+
+# Delete existing cluster for a clean start
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+    echo "Deleting existing Kind cluster '${CLUSTER_NAME}'..."
+    kind delete cluster --name "${CLUSTER_NAME}"
+fi
+
+# Recreate test disk for clean state (removes stale bootstrap credentials)
+echo "Recreating test disk for clean state..."
+"${PROJECT_ROOT}/tools/testing/setup-test-disk.sh" --force
+
 "${SETUP_KIND}"
 
 # Extract cluster CA certificate
@@ -57,13 +71,76 @@ kubectl create secret generic "bootstrap-token-${TOKEN_ID}" \
   --from-literal=token-secret="${TOKEN_SECRET}" \
   --from-literal=usage-bootstrap-authentication=true \
   --from-literal=usage-bootstrap-signing=true \
+  --from-literal=auth-extra-groups=system:bootstrappers:kubeadm:default-node-token \
   -n kube-system
 
 echo "Bootstrap token created: ${BOOTSTRAP_TOKEN}"
 
+# Verify bootstrap token works from host
+echo "Verifying bootstrap token authentication..."
+TOKEN_CHECK=$(curl -sk -H "Authorization: Bearer ${BOOTSTRAP_TOKEN}" "https://localhost:6443/api/v1/namespaces" -w "%{http_code}" -o /dev/null 2>&1)
+if [ "${TOKEN_CHECK}" = "403" ]; then
+    echo "✓ Bootstrap token authenticates (403 = authed but no perms on this resource, expected)"
+elif [ "${TOKEN_CHECK}" = "401" ]; then
+    echo "⚠ WARNING: Bootstrap token returned 401 - token auth may not be enabled on API server"
+    echo "  Checking API server flags..."
+    docker exec keel-test-control-plane cat /etc/kubernetes/manifests/kube-apiserver.yaml 2>/dev/null | grep -i bootstrap || echo "  No bootstrap flags found"
+else
+    echo "  Token check returned HTTP ${TOKEN_CHECK}"
+fi
+
 # Start QEMU in background
 echo "Starting KeelOS in QEMU..."
+
+# Pre-load container images onto the test disk's data partition
+# QEMU's SLIRP networking cannot pull images from container registries,
+# so we pre-populate the data partition with required images.
+# keel-init will mount this partition at /data/ and import images from /data/images/
+DISK_IMG="${PROJECT_ROOT}/build/sda.img"
+echo ">>> Pre-loading container images onto test disk..."
+LOOP_DEV=$(sudo losetup --find --show --partscan "$DISK_IMG")
+DATA_PART="${LOOP_DEV}p4"
+sleep 1
+if [ -b "$DATA_PART" ]; then
+    sudo mkfs.ext4 -q -F "$DATA_PART"
+    MOUNT_DIR=$(mktemp -d)
+    sudo mount "$DATA_PART" "$MOUNT_DIR"
+    sudo mkdir -p "${MOUNT_DIR}/images"
+
+    # Export kube-proxy image from Kind control plane's containerd
+    # (kindnet is replaced by static bridge CNI, so only kube-proxy needed)
+    IMAGES=$(docker exec keel-test-control-plane ctr --namespace k8s.io images list -q 2>/dev/null | grep -E "kube-proxy:" | grep -v sha256 || true)
+    echo "  Found images to export:"
+    echo "  $IMAGES"
+
+    set +e  # Don't fail on export errors
+    IMG_NUM=0
+    for img in $IMAGES; do
+        IMG_NUM=$((IMG_NUM + 1))
+        IMG_FILE="preload-${IMG_NUM}.tar"
+        echo "  Exporting $img as ${IMG_FILE}..."
+        # Pipe ctr export to stdout (-) and redirect to host file
+        docker exec keel-test-control-plane ctr --namespace k8s.io images export - "$img" > "/tmp/${IMG_FILE}" 2>/dev/null
+        if [ $? -eq 0 ] && [ -s "/tmp/${IMG_FILE}" ]; then
+            sudo cp "/tmp/${IMG_FILE}" "${MOUNT_DIR}/images/"
+            rm -f "/tmp/${IMG_FILE}"
+            echo "  ✓ Exported $img ($(du -h "${MOUNT_DIR}/images/${IMG_FILE}" | cut -f1))"
+        else
+            echo "  ⚠ Failed to export $img"
+            rm -f "/tmp/${IMG_FILE}"
+        fi
+    done
+    set -e
+
+    sudo umount "$MOUNT_DIR"
+    rmdir "$MOUNT_DIR"
+else
+    echo "  ⚠ Data partition not found, skipping image pre-loading"
+fi
+sudo losetup -d "$LOOP_DEV"
+
 rm -f "${LOG_FILE}"
+export EXTRA_APPEND="hostname=keelnode-test test_cni=1"
 nohup "${PROJECT_ROOT}/tools/testing/run-qemu.sh" > "${LOG_FILE}" 2>&1 &
 QEMU_PID=$!
 echo "QEMU PID: ${QEMU_PID}"
@@ -113,10 +190,14 @@ while true; do
     sleep 0.5
 done
 
+# QEMU user-mode (SLIRP) networking reaches the host at 10.0.2.2
+HOST_IP="10.0.2.2"
+echo "Using API server at: https://${HOST_IP}:6443"
+
 # Bootstrap the node
 echo "Bootstrapping node with Kubernetes credentials..."
 BOOTSTRAP_OUTPUT=$("${OSCTL}" --endpoint "${ENDPOINT}" bootstrap \
-    --api-server "https://10.0.2.2:6443" \
+    --api-server "https://${HOST_IP}:6443" \
     --token "${BOOTSTRAP_TOKEN}" \
     --ca-cert "${CA_CERT_FILE}" \
     --node-name "keelnode-test" 2>&1)
@@ -144,7 +225,7 @@ else
 fi
 
 # Check API server endpoint
-if echo "${STATUS_OUTPUT}" | grep -q "API Server.*https://10.0.2.2:6443"; then
+if echo "${STATUS_OUTPUT}" | grep -q "API Server.*https://${HOST_IP}:6443"; then
     echo "✓ API server endpoint is correct"
 else
     echo "!!! FAIL: API server endpoint mismatch !!!"
@@ -159,31 +240,139 @@ else
     exit 1
 fi
 
-# Wait for node to appear in cluster (optional check)
+# Debug: Check for CSRs from the node
+echo ""
+echo "Checking for Certificate Signing Requests..."
+kubectl get csr -o wide || true
+CSR_COUNT=$(kubectl get csr 2>/dev/null | grep -c keelnode || echo "0")
+echo "CSRs found: ${CSR_COUNT}"
+
+# Debug: Check if kubelet is actually running in QEMU
+echo ""
+echo "Checking QEMU logs for kubelet activity..."
+if grep -q "Starting kubelet" "${LOG_FILE}" 2>/dev/null; then
+    echo "✓ Kubelet startup detected in logs"
+    # Show last few kubelet-related log lines
+    echo "Recent kubelet logs:"
+    grep "kubelet" "${LOG_FILE}" 2>/dev/null | tail -10 || true
+else
+    echo "⚠ No kubelet startup messages found in logs"
+fi
+
+# Debug: Verify bootstrap config was applied
+echo ""
+echo "Verifying bootstrap configuration in guest..."
+VERIFY_OUTPUT=$("${OSCTL}" --endpoint "${ENDPOINT}" bootstrap-status 2>&1)
+if echo "${VERIFY_OUTPUT}" | grep -q "ca.crt"; then
+    echo "✓ CA certificate path detected in config"
+else
+    echo "⚠ CA certificate may not be configured"
+fi
+
+# Wait for node to appear in cluster
+echo ""
 echo "Checking if node appears in cluster (waiting up to 90s)..."
 NODE_TIMEOUT=90
 START_TIME=$(date +%s)
-NODE_FOUND=0
+NODE_NAME="keelnode-test"
+NODE_JOINED=0
 
 while true; do
     CURRENT_TIME=$(date +%s)
     ELAPSED=$((CURRENT_TIME - START_TIME))
     
     if [ $ELAPSED -gt $NODE_TIMEOUT ]; then
-        echo "⚠ Node did not appear in cluster after ${NODE_TIMEOUT}s"
-        echo "  This may be expected if kubelet is not fully functional yet."
-        echo "  Bootstrap configuration is still valid."
+        echo "✗ FAIL: Node did not appear in cluster after ${NODE_TIMEOUT}s"
+        echo "  Expected: Node '${NODE_NAME}' should appear in 'kubectl get nodes'"
+        echo "  Actual: Node not found"
+        echo ""
+        echo "Debug information:"
+        echo "  CSRs found: ${CSR_COUNT}"
+        kubectl get csr -o wide 2>/dev/null || echo "  No CSRs"
+        echo ""
+        echo "This indicates kubelet failed to join the cluster."
+        cleanup
+        exit 1
+    fi
+    
+    if kubectl get nodes "${NODE_NAME}" &>/dev/null; then
+        NODE_JOINED=1
+        NODE_STATUS=$(kubectl get node "${NODE_NAME}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+        echo "✓ Node joined cluster with status: ${NODE_STATUS}"
+        kubectl get nodes "${NODE_NAME}"
         break
     fi
     
-    if kubectl get nodes keelnode-test &>/dev/null; then
-        NODE_FOUND=1
-        echo "✓ Node 'keelnode-test' appeared in cluster!"
-        kubectl get nodes keelnode-test
+    sleep 3
+done
+
+# Wait for node to become Ready
+echo ""
+echo "Waiting for node to become Ready (CNI up)..."
+READY_TIMEOUT=600
+START_TIME=$(date +%s)
+NODE_READY_FLAG=0
+
+while true; do
+    CURRENT_TIME=$(date +%s)
+    ELAPSED=$((CURRENT_TIME - START_TIME))
+    
+    if [ $ELAPSED -gt $READY_TIMEOUT ]; then
+        echo "✗ FAIL: Node is not Ready after ${READY_TIMEOUT}s"
+        echo "  This likely means CNI failed to start, possibly due to container runtime errors."
+        echo "  Node status:"
+        kubectl get nodes "${NODE_NAME}" -o wide
+        echo "  Node partial description:"
+        kubectl describe node "${NODE_NAME}" | grep -A 10 "Conditions"
+        echo ""
+        echo "  === OCI/Runtime errors from QEMU log ==="
+        grep -i "OCI runtime\|pivot_root\|runc create failed\|RunPodSandbox.*failed\|StartContainer.*failed" "${LOG_FILE}" 2>/dev/null | tail -20 || echo "  (no OCI errors found in log)"
+        echo "  === End OCI errors ==="
+        echo ""
+        echo "  === Persistent storage status ==="
+        grep -i "persistent storage\|mount.*data\|mkfs\|Bind-mounted" "${LOG_FILE}" 2>/dev/null | tail -10 || echo "  (no storage messages found)"
+        echo "  === End storage status ==="
+        echo ""
+        echo "  === Image import status ==="
+        grep -i "Scanning\|import\|pre-loaded\|images dir\|data.images\|share.*keel\|Successfully" "${LOG_FILE}" 2>/dev/null | tail -20 || echo "  (no import messages found)"
+        echo "  === End image import status ==="
+        echo ""
+        echo "  === Pod status ==="
+        kubectl get pods -A -o wide 2>/dev/null || echo "  (could not get pod status)"
+        echo "  === End pod status ==="
+        echo ""
+        echo "  === Pod events ==="
+        kubectl get events -n kube-system --sort-by=.lastTimestamp 2>/dev/null | tail -20 || echo "  (could not get events)"
+        echo "  === End pod events ==="
+        echo ""
+        echo "  === Kindnet pod logs (all pods) ==="
+        for pod in $(kubectl get pods -n kube-system -o name 2>/dev/null | grep kindnet); do
+            podname=$(echo "$pod" | sed 's|pod/||')
+            node=$(kubectl get "$pod" -n kube-system -o jsonpath='{.spec.nodeName}' 2>/dev/null || echo "unknown")
+            phase=$(kubectl get "$pod" -n kube-system -o jsonpath='{.status.phase}' 2>/dev/null || echo "unknown")
+            echo "  --- ${podname} (node=${node}, phase=${phase}) ---"
+            echo "  Describe:"
+            kubectl describe pod -n kube-system "$podname" 2>/dev/null | grep -A 5 "State:\|Last State:\|Reason:\|Exit Code:\|Message:" | head -20
+            echo "  Current logs:"
+            kubectl logs -n kube-system "$podname" 2>/dev/null | tail -20 || echo "  (no current logs)"
+            echo "  Previous logs:"
+            kubectl logs -n kube-system "$podname" --previous 2>/dev/null | tail -20 || echo "  (no previous logs)"
+            echo ""
+        done
+        echo "  === End kindnet logs ==="
+        cleanup
+        exit 1
+    fi
+    
+    NODE_READY_STATUS=$(kubectl get node "${NODE_NAME}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [ "${NODE_READY_STATUS}" = "True" ]; then
+        echo "✓ Node is Ready!"
+        NODE_READY_FLAG=1
         break
     fi
     
-    sleep 2
+    echo "  Waiting for Ready status (Current: ${NODE_READY_STATUS}, elapsed: ${ELAPSED}s)..."
+    sleep 5
 done
 
 # Final summary
@@ -196,10 +385,11 @@ echo "✓ Bootstrap token generated"
 echo "✓ KeelOS agent started in QEMU"
 echo "✓ Bootstrap command executed successfully"
 echo "✓ Bootstrap status verified"
-if [ $NODE_FOUND -eq 1 ]; then
+if [ $NODE_JOINED -eq 1 ]; then
     echo "✓ Node joined cluster successfully"
-else
-    echo "⚠ Node did not join cluster (kubelet may need additional work)"
+fi
+if [ $NODE_READY_FLAG -eq 1 ]; then
+    echo "✓ Node became Ready (CNI active)"
 fi
 echo "========================================="
 echo ">>> PASS: Bootstrap test completed successfully!"

--- a/tools/testing/test-network.sh
+++ b/tools/testing/test-network.sh
@@ -38,21 +38,25 @@ echo ""
 TESTS_PASSED=0
 TESTS_FAILED=0
 
+# Each test uses a unique port to avoid stale port state from previous QEMU instances
+NEXT_PORT=50052
+
 # Helper function to start QEMU
 start_qemu() {
     local test_name="$1"
-    echo -e "${YELLOW}[${test_name}] Starting QEMU...${NC}"
     
-    # Ensure port 50052 is available
-    local pids=$(lsof -ti:50052 2>/dev/null)
-    if [ -n "$pids" ]; then
-        echo "[${test_name}] Port 50052 is in use (PIDs: $pids), killing processes..."
-        echo "$pids" | xargs kill -9 2>/dev/null || true
-        sleep 2
-    fi
+    # Assign a unique port for this test
+    CURRENT_PORT=$NEXT_PORT
+    NEXT_PORT=$((NEXT_PORT + 1))
+    
+    echo -e "${YELLOW}[${test_name}] Starting QEMU (port ${CURRENT_PORT})...${NC}"
+    
+    # Copy disk image for this test (avoids write lock conflicts between QEMU instances)
+    CURRENT_DISK="${BUILD_DIR}/sda-${test_name}.img"
+    cp "${BUILD_DIR}/sda.img" "${CURRENT_DISK}"
     
     rm -f "${LOG_FILE}"
-    "${PROJECT_ROOT}/tools/testing/run-qemu.sh" > "${LOG_FILE}" 2>&1 &
+    QEMU_HOST_PORT=$CURRENT_PORT QEMU_DISK="$CURRENT_DISK" "${PROJECT_ROOT}/tools/testing/run-qemu.sh" > "${LOG_FILE}" 2>&1 &
     QEMU_PID=$!
     
     echo "[${test_name}] QEMU PID: ${QEMU_PID}"
@@ -78,9 +82,9 @@ start_qemu() {
             echo "[${test_name}] Waiting for gRPC server to be ready..."
             local grpc_ready=false
             for i in {1..20}; do
-                if nc -z localhost 50052 2>/dev/null; then
+                if nc -z localhost $CURRENT_PORT 2>/dev/null; then
                     grpc_ready=true
-                    echo "[${test_name}] gRPC server is accepting connections"
+                    echo "[${test_name}] gRPC server is accepting connections on port ${CURRENT_PORT}"
                     sleep 2  # Extra stabilization time
                     break
                 fi
@@ -88,7 +92,7 @@ start_qemu() {
             done
             
             if [ "$grpc_ready" = false ]; then
-                echo -e "${RED}[${test_name}] WARNING: gRPC server not responding on port 50052${NC}"
+                echo -e "${RED}[${test_name}] WARNING: gRPC server not responding on port ${CURRENT_PORT}${NC}"
                 sleep 2  # Try anyway
             fi
             
@@ -111,34 +115,17 @@ stop_qemu() {
     local test_name="$1"
     echo "[${test_name}] Stopping QEMU (PID: ${QEMU_PID})"
     kill -9 $QEMU_PID 2>/dev/null || true
-    
-    # Wait for the port to be released (up to 10 seconds)
-    local port_free=false
-    for i in {1..20}; do
-        if ! lsof -ti:50052 >/dev/null 2>&1 && ! ss -tuln 2>/dev/null | grep -q ":50052 "; then
-            port_free=true
-            echo "[${test_name}] Port 50052 released"
-            break
-        fi
-        sleep 0.5
-    done
-    
-    if [ "$port_free" = false ]; then
-        echo "[${test_name}] Warning: Port 50052 may still be in use"
-        # Force kill any process using the port
-        local pids=$(lsof -ti:50052 2>/dev/null)
-        if [ -n "$pids" ]; then
-            echo "$pids" | xargs kill -9 2>/dev/null || true
-        fi
-        sleep 1
-    fi
+    wait $QEMU_PID 2>/dev/null || true
+    # Clean up per-test disk image copy
+    rm -f "${CURRENT_DISK}" 2>/dev/null || true
+    echo "[${test_name}] QEMU stopped"
 }
 
 # Helper function to run osctl command
 run_osctl() {
     local cmd="$*"
     echo "    $ osctl ${cmd}"
-    "${OSCTL}" --endpoint http://localhost:50052 $cmd
+    "${OSCTL}" --endpoint http://localhost:${CURRENT_PORT} $cmd
 }
 
 # Helper function to check network config


### PR DESCRIPTION
## Description

Implement kubelet TLS bootstrapping so KeelOS nodes can join Kubernetes clusters. This adds the full lifecycle: persistent disk mounting for container data, containerd and kubelet service management, cgroup v2 controllers, and all necessary kernel/initramfs dependencies. The CI test infrastructure (test-bootstrap-kind) validates the end-to-end flow using a Kind cluster.

**Which issue(s) this PR fixes**:

## Type of Change


- [x] New feature (non-breaking change which adds functionality)
- [x] CI/CD changes


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
KeelOS nodes can now join Kubernetes clusters via kubelet TLS bootstrap. The keel-init service manages persistent storage, containerd, and kubelet lifecycle. gRPC connections (keel-agent server and osctl client) now include HTTP/2 keepalive and timeouts for reliability.
