### PR TITLE
docs: update documentation for kubelet TLS bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Kubelet TLS Bootstrap**: KeelOS nodes can now join Kubernetes clusters via `osctl bootstrap`. Supports bootstrap token and kubeconfig authentication methods.
+- **Persistent Storage**: `keel-init` mounts a data disk and bind-mounts `/var/lib/containerd`, `/var/lib/kubelet`, and `/var/lib/keel` for persistent container and kubelet state.
+- **Cgroup v2**: `keel-init` sets up cgroup v2 with `cpu`, `memory`, `io`, `pids`, and `cpuset` controllers for container resource management.
+- **Kubelet Lifecycle Management**: `keel-init` supervision loop manages kubelet bootstrap → permanent kubeconfig transition and restart signals.
+- **Pre-loaded Container Images**: `keel-init` imports pre-loaded images (e.g., pause container) into containerd on startup.
+- **gRPC Keepalive**: `keel-agent` server and `osctl` client include HTTP/2 keepalive and timeouts for connection reliability.
+- **Bootstrap Status**: `osctl bootstrap-status` command to check Kubernetes join state.
+- **Network Management**: `osctl network` commands for configuring static IP, DHCP, IPv6, and DNS.
+- **CI**: `test-bootstrap-kind` integration test validates end-to-end kubelet TLS bootstrapping using a Kind cluster.
+
 ## [v0.1.0] - 2026-01-27
 
 ### Added

--- a/cmd/keel-init/README.md
+++ b/cmd/keel-init/README.md
@@ -10,26 +10,45 @@ The PID 1 init process for KeelOS.
 `keel-init` is the first process launched by the kernel. Unlike `systemd` or `sysvinit`, it is not a general-purpose service manager. Its scope is strictly bounded:
 
 1.  **Early Boot**:
-    *   Mounts pseudo-filesystems (`/proc`, `/sys`, `/dev`, `/run`, `/sys/fs/cgroup`).
+    *   Mounts pseudo-filesystems (`/proc`, `/sys`, `/dev`, `/run`, `/tmp`, `/sys/fs/cgroup`).
     *   Populates `/dev` using `devtmpfs`.
-2.  **Storage Setup**:
-    *   Scans block devices for the `MATIC_STATE` partition.
-    *   Mounts the persistent overlay filesystem.
-3.  **Networking**:
+2.  **Persistent Storage**:
+    *   Detects data disk candidates (`/dev/sda4`, `/dev/sda`).
+    *   Formats with ext4 if unformatted, mounts to `/data`.
+    *   Bind-mounts `/data/containerd` → `/var/lib/containerd`, `/data/kubelet` → `/var/lib/kubelet`, `/data/keel` → `/var/lib/keel`.
+3.  **Cgroup v2 Setup**:
+    *   Mounts cgroup2 filesystem at `/sys/fs/cgroup`.
+    *   Enables controllers: `cpu`, `memory`, `io`, `pids`, `cpuset`.
+4.  **Hostname**:
+    *   Reads saved hostname from `/var/lib/keel/hostname` or generates a unique fallback.
+5.  **Networking**:
     *   Configures the loopback interface (`lo`).
-    *   (Future) Sets up minimal host networking (DHCP or static).
-4.  **Supervisor**:
-    *   Starts and supervises `containerd`.
-    *   Starts and supervises `kubelet`.
-    *   Starts and supervises `keel-agent`.
-5.  **Reaper**:
+    *   Applies saved network configuration or falls back to DHCP.
+6.  **Supervisor**:
+    *   Starts and supervises `keel-agent`, `containerd`, and `kubelet`.
+    *   Restarts `containerd` and `keel-agent` automatically on crash (with exponential backoff for the agent).
+    *   Manages kubelet bootstrap lifecycle: detects bootstrap kubeconfig, handles restart signals from `keel-agent`, and switches kubelet from bootstrap to permanent kubeconfig after CSR approval.
+    *   Imports pre-loaded container images into containerd on startup.
+7.  **Reaper**:
     *   Reaps orphaned zombie processes to prevent resource exhaustion.
-6.  **Shutdown**:
+8.  **Shutdown**:
     *   Handles `SIGTERM`/`SIGINT` to gracefully shut down services and unmount filesystems.
+
+## Kubelet Modes
+
+`keel-init` manages three kubelet operating modes:
+
+| Mode | Condition | Behavior |
+|------|-----------|----------|
+| **Standalone** | No kubeconfig files exist | Kubelet runs without cluster connection |
+| **Bootstrap** | Bootstrap kubeconfig exists, no permanent kubeconfig | Kubelet uses `--bootstrap-kubeconfig` to submit CSR |
+| **Cluster** | Permanent kubeconfig exists | Kubelet uses permanent credentials |
+
+The supervision loop watches for the restart signal file (`/run/keel/restart-kubelet`) created by `keel-agent` during the `osctl bootstrap` flow, and also detects when the permanent kubeconfig appears after CSR approval.
 
 ## Configuration
 
-`keel-init` is largely zero-config, relying on convention (e.g., standard mount paths) rather than configuration files. However, it may read kernel command-line arguments (e.g., `matic.debug`) to toggle verbose logging.
+`keel-init` is largely zero-config, relying on convention (e.g., standard mount paths) rather than configuration files. However, it may read kernel command-line arguments (e.g., `keel.test_mode`) to toggle test behavior.
 
 ## Development
 

--- a/cmd/osctl/README.md
+++ b/cmd/osctl/README.md
@@ -7,27 +7,35 @@ The Command Line Interface for administering KeelOS nodes.
 
 ## Overview
 
-`osctl` is a remote client that talks to `keel-agent` via gRPC. It mimics a standard CLI tool but executes operations remotely.
+`osctl` is a remote client that talks to `keel-agent` via gRPC. It auto-loads mTLS certificates from a local cert store when available, falling back to plain HTTP otherwise.
 
 ## Usage
 
 ```bash
 # Get node status
-osctl --addr <NODE_IP>:50051 status
+osctl --endpoint http://<NODE_IP>:50051 status
 
 # Install a new OS version
-osctl --addr <NODE_IP>:50051 install --image <OCI_IMAGE_URL> --version 1.0.1
+osctl --endpoint http://<NODE_IP>:50051 update --source <IMAGE_URL>
 
 # Reboot the node
-osctl --addr <NODE_IP>:50051 reboot
+osctl --endpoint http://<NODE_IP>:50051 reboot
 
-# Stream logs
-osctl --addr <NODE_IP>:50051 logs --component kubelet
+# Join a Kubernetes cluster
+osctl --endpoint http://<NODE_IP>:50051 bootstrap \
+  --api-server https://<K8S_API>:6443 \
+  --token <TOKEN> --ca-cert ca.crt
+
+# Check bootstrap status
+osctl --endpoint http://<NODE_IP>:50051 bootstrap-status
+
+# Enable mTLS
+osctl init bootstrap --node <NODE_IP>
 ```
 
 ## Configuration
 
-Credentials and default endpoints can be stored in `~/.config/osctl.yaml` (Planned).
+Certificates are managed via a local cert store (`~/.config/osctl/`). Run `osctl init bootstrap --node <ip>` to generate and exchange bootstrap certificates.
 
 ## Build
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,10 +23,15 @@ sequenceDiagram
     BIOS/UEFI->>Kernel: Load bzImage + initramfs
     Kernel->>keel-init: Execute /init (PID 1)
     keel-init->>keel-init: Mount /proc, /sys, /dev
-    keel-init->>keel-init: Mount persistent storage
-    keel-init->>containerd: Start containerd
-    keel-init->>kubelet: Start kubelet
+    keel-init->>keel-init: Mount persistent storage (/data)
+    keel-init->>keel-init: Bind-mount /var/lib/containerd, kubelet, keel
+    keel-init->>keel-init: Setup cgroup v2
+    keel-init->>keel-init: Set hostname
+    keel-init->>keel-init: Configure networking
     keel-init->>keel-agent: Start gRPC agent
+    keel-init->>containerd: Start containerd
+    keel-init->>containerd: Import pre-loaded images
+    keel-init->>kubelet: Start kubelet (standalone or bootstrap mode)
     keel-agent-->>keel-agent: Listen on :50051
 ```
 
@@ -34,11 +39,11 @@ sequenceDiagram
 
 | Component       | Role                                      |
 |-----------------|-------------------------------------------|
-| `keel-init`    | PID 1. Mounts filesystems, supervises processes, reaps zombies. |
-| `keel-agent`   | gRPC server. Handles updates, reboots, configuration. |
-| `osctl`         | CLI client for `keel-agent`. |
+| `keel-init`    | PID 1. Mounts filesystems, sets up persistent storage and cgroup v2, supervises processes, manages kubelet bootstrap lifecycle, reaps zombies. |
+| `keel-agent`   | gRPC server. Handles updates, reboots, Kubernetes bootstrap, network configuration, and certificate management. |
+| `osctl`         | CLI client for `keel-agent`. Manages mTLS certificates via local cert store. |
 | `containerd`    | Container runtime (stock, unmodified). |
-| `kubelet`       | Kubernetes node agent (stock, unmodified). |
+| `kubelet`       | Kubernetes node agent (stock, unmodified). Supports standalone, bootstrap, and cluster modes. |
 
 ## Partition Layout
 

--- a/docs/getting-started/first-boot.md
+++ b/docs/getting-started/first-boot.md
@@ -13,16 +13,19 @@ The Linux kernel initializes hardware, mounts the `initramfs`, and executes the 
 ### 3. keel-init (PID 1)
 `keel-init` is the heart of the boot process. It is a statically linked Rust binary that performs the following steps sequentially:
 
-1.  **Mount API Filesystems**: Mounts `/proc`, `/sys`, `/dev`, and `/run`.
-2.  **Load Kernel Modules**: Loads necessary drivers for networking and storage.
-3.  **Network Setup**: Brings up the loopback interface (`lo`) and attempts DHCP on the primary interface (`eth0`).
-4.  **Partition Discovery**: Looks for the persistent data partition on the attached disk.
-    *   *If found*: Mounts it to `/var/lib/keel`.
-    *   *If not found*: Formats the disk and creates the partition structure (First Boot).
-5.  **Service Startup**:
-    *   Starts `containerd` to manage container lifecycles.
-    *   Starts `keel-agent` to listen for API commands.
-    *   Starts `kubelet` to join the Kubernetes cluster.
+1.  **Mount API Filesystems**: Mounts `/proc`, `/sys`, `/dev`, `/tmp`, and `/run`.
+2.  **Mount Persistent Storage**: Detects a data disk (e.g., `/dev/sda4`), formats it with ext4 if needed, mounts it at `/data`, and bind-mounts subdirectories:
+    - `/data/containerd` → `/var/lib/containerd`
+    - `/data/kubelet` → `/var/lib/kubelet`
+    - `/data/keel` → `/var/lib/keel`
+3.  **Setup Cgroup v2**: Mounts the cgroup2 filesystem and enables controllers (`cpu`, `memory`, `io`, `pids`, `cpuset`) required by kubelet and container runtimes.
+4.  **Set Hostname**: Reads a saved hostname from `/var/lib/keel/hostname` or generates a unique one (e.g., `keelos-<id>`).
+5.  **Network Setup**: Brings up the loopback interface (`lo`) and applies saved network configuration or falls back to DHCP.
+6.  **Service Startup**:
+    - Starts `keel-agent` to listen for API commands.
+    - Starts `containerd` to manage container lifecycles.
+    - Imports pre-loaded container images (e.g., the pause image).
+    - Starts `kubelet` — in standalone mode, bootstrap mode, or cluster mode depending on available kubeconfig files.
 
 ## Node Identity
 

--- a/docs/guides/kubernetes-bootstrap.md
+++ b/docs/guides/kubernetes-bootstrap.md
@@ -1,20 +1,21 @@
 # Kubernetes Bootstrap Guide
 
-This guide describes how to join a KeelOS node to an existing Kubernetes cluster.
+This guide describes how to join a KeelOS node to an existing Kubernetes cluster using kubelet TLS bootstrapping.
 
 ## Overview
 
 KeelOS nodes can join Kubernetes clusters using the `osctl bootstrap` command, which configures the kubelet to connect to your cluster's API server. The bootstrap process supports two authentication methods:
 
-1. **Bootstrap Token** - Uses Kubernetes TLS bootstrapping (recommended for production)
-2. **Kubeconfig File** - Uses pre-generated credentials (simpler for testing)
+1. **Bootstrap Token** — Uses Kubernetes TLS bootstrapping (recommended for production)
+2. **Kubeconfig File** — Uses pre-generated credentials (simpler for testing)
 
 ## Prerequisites
 
-Before bootstrapping a KeelOS node, you need:
+Before bootstrapping a KeelOS node, ensure the following:
 
 - A running Kubernetes cluster with an accessible API server
 - Network connectivity from the KeelOS node to the API server
+- A persistent data disk attached to the node (for container images, kubelet state, and bootstrap config)
 - Either:
   - A bootstrap token and cluster CA certificate (for token-based auth)
   - OR a valid kubeconfig file with node credentials
@@ -43,7 +44,7 @@ Get the cluster's CA certificate:
 ```bash
 kubectl config view --raw \
   -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' \
-  | base64 -d > /tmp/ca.crt
+  | base64 -d > ca.crt
 ```
 
 ### Step 3: Bootstrap the Node
@@ -54,7 +55,7 @@ Transfer the CA certificate to a location accessible by `osctl`, then run:
 osctl --endpoint http://<keelos-node-ip>:50051 bootstrap \
   --api-server https://<k8s-api-server>:6443 \
   --token <bootstrap-token> \
-  --ca-cert /tmp/ca.crt
+  --ca-cert ca.crt
 ```
 
 **Example:**
@@ -62,7 +63,7 @@ osctl --endpoint http://<keelos-node-ip>:50051 bootstrap \
 osctl --endpoint http://192.168.1.100:50051 bootstrap \
   --api-server https://k8s.example.com:6443 \
   --token abcdef.0123456789abcdef \
-  --ca-cert /tmp/ca.crt
+  --ca-cert ca.crt
 ```
 
 ### Step 4: Verify Node Joined
@@ -73,7 +74,7 @@ Check that the node appears in your cluster:
 kubectl get nodes
 ```
 
-You should see your KeelOS node listed (it may take 30-60 seconds to appear).
+You should see your KeelOS node listed (it may take 30–60 seconds to appear).
 
 ---
 
@@ -113,13 +114,13 @@ osctl --endpoint http://192.168.1.100:50051 bootstrap \
 
 ### Override Node Name
 
-By default, the node uses its hostname. To override:
+By default, the node uses its hostname (or a name from `bootstrap.json` if previously bootstrapped). To override:
 
 ```bash
-osctl bootstrap \
+osctl --endpoint http://<keelos-node-ip>:50051 bootstrap \
   --api-server https://k8s.example.com:6443 \
   --token <token> \
-  --ca-cert /tmp/ca.crt \
+  --ca-cert ca.crt \
   --node-name keelos-worker-01
 ```
 
@@ -140,33 +141,80 @@ This shows:
 
 ---
 
+## How It Works
+
+When you run `osctl bootstrap`, the following sequence occurs:
+
+### 1. Bootstrap Request (osctl → keel-agent)
+
+1. `osctl` reads the CA certificate and/or kubeconfig file from local disk
+2. Sends a `BootstrapKubernetesRequest` to the `keel-agent` gRPC server
+3. `keel-agent` validates inputs (API server required, token+CA or kubeconfig required)
+
+### 2. Configuration Persistence (keel-agent)
+
+4. Creates the Kubernetes directory at `/var/lib/keel/kubernetes/`
+5. Writes the CA certificate to `/var/lib/keel/kubernetes/ca.crt`
+6. Generates (from token) or writes (from file) the kubeconfig to `/var/lib/keel/kubernetes/kubelet.kubeconfig`
+7. Saves bootstrap state to `/var/lib/keel/kubernetes/bootstrap.json` (records API server, node name, kubeconfig path, and timestamp)
+8. Creates the restart signal file at `/run/keel/restart-kubelet`
+
+### 3. Kubelet Restart (keel-init supervision loop)
+
+9. `keel-init`'s supervision loop detects the restart signal
+10. Stops the running kubelet process
+11. Restarts kubelet with `--bootstrap-kubeconfig=/var/lib/keel/kubernetes/kubelet.kubeconfig`
+
+### 4. TLS Bootstrap (kubelet → API server)
+
+12. Kubelet uses the bootstrap token to authenticate with the API server
+13. Kubelet submits a Certificate Signing Request (CSR) for a permanent client certificate
+14. Once the CSR is approved, kubelet writes its permanent kubeconfig to `/var/lib/kubelet/kubeconfig`
+15. `keel-init` detects the permanent kubeconfig and restarts kubelet one final time to switch from bootstrap to permanent credentials
+
+### Key Paths
+
+| Path | Purpose |
+|------|---------|
+| `/var/lib/keel/kubernetes/kubelet.kubeconfig` | Bootstrap kubeconfig (token-based, temporary) |
+| `/var/lib/keel/kubernetes/ca.crt` | Cluster CA certificate |
+| `/var/lib/keel/kubernetes/bootstrap.json` | Bootstrap state (API server, node name, timestamp) |
+| `/var/lib/kubelet/kubeconfig` | Permanent kubeconfig (post-CSR, long-lived) |
+| `/var/lib/kubelet/pki/` | Kubelet client certificates |
+| `/run/keel/restart-kubelet` | Restart signal file |
+| `/etc/kubernetes/kubelet-config.yaml` | Kubelet configuration |
+
+### Persistent Storage
+
+All bootstrap configuration is stored under `/var/lib/keel/`, which is bind-mounted to persistent storage (`/data/keel/` on the data disk). This ensures bootstrap configuration survives reboots.
+
+---
+
 ## Troubleshooting
 
 ### Node Not Appearing in Cluster
 
-1. **Check kubelet logs:**
+1. **Check bootstrap status:**
    ```bash
-   osctl --endpoint http://<keelos-node-ip>:50051 logs --component kubelet
+   osctl --endpoint http://<keelos-node-ip>:50051 bootstrap-status
    ```
 
 2. **Verify network connectivity:**
    ```bash
-   # From KeelOS node
+   # From a machine that can reach the KeelOS node
    curl -k https://<k8s-api-server>:6443/healthz
    ```
 
-3. **Check bootstrap status:**
-   ```bash
-   osctl --endpoint http://<keelos-node-ip>:50051 bootstrap-status
-   ```
+3. **Check that persistent storage is mounted:**
+   The data disk must be available so kubelet state persists. Without it, container images and kubelet data live in RAM and fill up quickly, causing `DiskPressure`.
 
 ### Authentication Errors
 
 **Error: "Unauthorized" or "x509: certificate signed by unknown authority"**
 
-- Verify the CA certificate is correct
+- Verify the CA certificate is correct and matches the cluster
 - Ensure the bootstrap token is valid and not expired
-- Check that the API server endpoint URL is correct
+- Check that the API server endpoint URL is correct (include the port)
 
 ### Token Expired
 
@@ -179,41 +227,26 @@ Bootstrap tokens have a limited lifetime. If your token expired:
 
 If kubelet fails to start after bootstrap:
 
-1. Check that containerd is running:
+1. **Check that containerd is running.** Kubelet requires containerd for CRI operations. Verify the node status:
    ```bash
    osctl --endpoint http://<keelos-node-ip>:50051 status
    ```
 
-2. Review kubelet configuration:
-   ```bash
-   # The kubeconfig should exist at:
-   # /var/lib/keel/kubernetes/kubelet.kubeconfig
-   ```
+2. **Verify kubeconfig exists:**
+   The bootstrap kubeconfig should be at `/var/lib/keel/kubernetes/kubelet.kubeconfig`.
+
+3. **Check persistent storage:**
+   If the data disk is not mounted, kubelet will run out of disk space for container images. Ensure `/data` is mounted and the bind-mounts for `/var/lib/containerd`, `/var/lib/kubelet`, and `/var/lib/keel` are active.
 
 ---
 
 ## Security Considerations
 
-- **Bootstrap tokens are sensitive** - Treat them like passwords. Anyone with a valid bootstrap token can add nodes to your cluster.
-- **Use short-lived tokens** - Set token duration to the minimum needed (e.g., 1-24 hours).
-- **Rotate certificates** - KeelOS kubelet supports automatic certificate rotation when using bootstrap tokens.
-- **Network security** - Ensure the API server is only accessible from trusted networks.
-
----
-
-## How It Works
-
-When you run `osctl bootstrap`:
-
-1. **keel-agent** receives the bootstrap request
-2. Creates `/var/lib/keel/kubernetes/` directory
-3. Writes the CA certificate to `/var/lib/keel/kubernetes/ca.crt`
-4. Generates a kubeconfig file at `/var/lib/keel/kubernetes/kubelet.kubeconfig`
-5. Updates kubelet configuration to use the kubeconfig
-6. Signals kubelet to restart with new configuration
-7. Kubelet connects to the API server and registers the node
-
-The kubeconfig persists across reboots on the `/var/lib/keel` partition.
+- **Bootstrap tokens are sensitive** — Treat them like passwords. Anyone with a valid bootstrap token can add nodes to your cluster.
+- **Use short-lived tokens** — Set token duration to the minimum needed (e.g., 1–24 hours).
+- **Rotate certificates** — KeelOS kubelet supports automatic certificate rotation when using bootstrap tokens.
+- **Network security** — Ensure the API server is only accessible from trusted networks.
+- **mTLS for osctl** — Use `osctl init bootstrap --node <ip>` to enable mTLS between your workstation and the KeelOS node, preventing unauthorized management access.
 
 ---
 
@@ -221,10 +254,10 @@ The kubeconfig persists across reboots on the `/var/lib/keel` partition.
 
 After bootstrapping:
 
-- **Deploy workloads** - Your KeelOS node is ready to run Kubernetes pods
-- **Monitor node health** - Use `kubectl describe node <node-name>`
-- **OS updates** - Use `osctl update` to manage OS updates without disrupting cluster membership
-- **Decommission** - To remove a node, drain it first: `kubectl drain <node-name> --ignore-daemonsets`
+- **Deploy workloads** — Your KeelOS node is ready to run Kubernetes pods
+- **Monitor node health** — Use `kubectl describe node <node-name>`
+- **OS updates** — Use `osctl update` to manage OS updates without disrupting cluster membership
+- **Decommission** — To remove a node, drain it first: `kubectl drain <node-name> --ignore-daemonsets`
 
 ---
 
@@ -232,5 +265,5 @@ After bootstrapping:
 
 - [KeelOS Architecture](../learn-more/architecture.md)
 - [First Boot Guide](../getting-started/first-boot.md)
-- [API Management](../learn-more/api-management.md)
+- [osctl Reference](../reference/osctl.md)
 - [Kubernetes TLS Bootstrapping](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -138,7 +138,7 @@ After booting KeelOS:
 3. Use `osctl` to manage the node remotely
 
 ```bash
-osctl --addr <NODE_IP>:50051 status
+osctl --endpoint http://<NODE_IP>:50051 status
 ```
 
 See [Using osctl](./using-osctl.md) for complete CLI reference.

--- a/docs/platform-installation/local-qemu.md
+++ b/docs/platform-installation/local-qemu.md
@@ -59,7 +59,7 @@ To access services inside the VM, we forward ports to localhost.
 Because of this forwarding, you must target port `50052` when running `osctl` on your host:
 
 ```bash
-osctl --addr 127.0.0.1:50052 status
+osctl --endpoint http://127.0.0.1:50052 status
 ```
 
 ## Storage

--- a/docs/reference/osctl.md
+++ b/docs/reference/osctl.md
@@ -1,16 +1,15 @@
 # osctl CLI Reference
 
-`osctl` is the command-line interface for managing KeelOS nodes. It interacts with the `keel-agent` via gRPC.
+`osctl` is the command-line interface for managing KeelOS nodes. It communicates with `keel-agent` via gRPC and auto-loads mTLS certificates from a local cert store when available.
 
 ## Global Flags
 
 | Flag | Description | Default |
 | :--- | :--- | :--- |
-| `--addr <address>` | Address of the target node (host:port). | `127.0.0.1:50051` |
-| `--cert <path>` | Path to client certificate (mTLS). | *(Optional)* |
-| `--key <path>` | Path to client key (mTLS). | *(Optional)* |
-| `--ca <path>` | Path to Cluster CA certificate. | *(Optional)* |
-| `--insecure` | Skip TLS verification (Dev/Test only). | `false` |
+| `--endpoint <url>` | gRPC endpoint of the target node. | `http://[::1]:50051` |
+
+> [!TIP]
+> Run `osctl init bootstrap --node <ip>` to enable mTLS. After that, `osctl` auto-loads certificates from the local cert store for all subsequent connections.
 
 ## Commands
 
@@ -32,15 +31,18 @@ osctl health
 ```
 **Output:**
 *   Overall Status (`healthy`, `degraded`, `unhealthy`)
-*   Individual check results
+*   Individual check results with duration
 
-### `install`
+### `update`
 Installs a new OS image to the inactive partition.
 ```bash
-osctl install --image <url> [--verify-signature]
+osctl update --source <url> [--sha256 <hash>] [--delta] [--fallback] [--full-image-url <url>]
 ```
-*   `--image`: URL or OCI reference to the SquashFS image.
-*   `--verify-signature`: Enforce signature verification before installing.
+*   `--source`: URL of the SquashFS image (or delta file if `--delta` is set).
+*   `--sha256`: Expected SHA256 checksum for verification.
+*   `--delta`: Treat the source as a delta file.
+*   `--fallback`: Fall back to full image download if delta fails.
+*   `--full-image-url`: URL for the full image (used as fallback).
 
 ### `reboot`
 Reboots the node.
@@ -48,14 +50,34 @@ Reboots the node.
 osctl reboot [--reason "Reason for reboot"]
 ```
 
-### `schedule update`
-Schedules an update for a future time or specific maintenance window.
+### `bootstrap`
+Joins the node to a Kubernetes cluster via kubelet TLS bootstrapping.
 ```bash
-osctl schedule update \
-  --source <url> \
-  --at "2023-12-01T04:00:00Z" \
-  --enable-auto-rollback
+osctl bootstrap \
+  --api-server <url> \
+  [--token <token> --ca-cert <path>] \
+  [--kubeconfig <path>] \
+  [--node-name <name>]
 ```
+*   `--api-server`: Kubernetes API server endpoint (required).
+*   `--token`: Bootstrap token (`<token-id>.<token-secret>`). Requires `--ca-cert`.
+*   `--ca-cert`: Path to the cluster CA certificate file.
+*   `--kubeconfig`: Path to a pre-generated kubeconfig file (alternative to token auth).
+*   `--node-name`: Override the node name (default: hostname).
+
+Either `--token` (with `--ca-cert`) or `--kubeconfig` must be provided.
+
+### `bootstrap-status`
+Shows the current Kubernetes bootstrap state.
+```bash
+osctl bootstrap-status
+```
+**Output:**
+*   Whether the node is bootstrapped
+*   API server endpoint
+*   Node name
+*   Kubeconfig path
+*   Bootstrap timestamp
 
 ### `rollback`
 Manages rollback operations.
@@ -64,11 +86,42 @@ Manages rollback operations.
 osctl rollback history
 
 # Trigger Manual Rollback
-osctl rollback trigger --reason "Emergency"
+osctl rollback trigger [--reason "Emergency"]
 ```
 
-### `logs`
-Streams logs from system components.
+### `init`
+Certificate initialization commands.
+
 ```bash
-osctl logs --component <kubelet|containerd|agent> [--follow]
+# Generate a 24-hour bootstrap certificate for mTLS
+osctl init bootstrap --node <ip>
+
+# Initialize with Kubernetes-signed operational certificate (planned)
+osctl init kubeconfig
+```
+
+### `network`
+Network management commands.
+
+```bash
+# Show network status
+osctl network status
+
+# Configure static IP
+osctl network config set --interface eth0 --ip 10.0.0.5/24 --gateway 10.0.0.1
+
+# Configure DHCP
+osctl network config set --interface eth0 --dhcp
+
+# Configure IPv6
+osctl network config set --interface eth0 --ipv6 fd00::1/64 --ipv6-gateway fd00::1
+
+# Enable IPv6 SLAAC
+osctl network config set --interface eth0 --ipv6-auto
+
+# Show saved network config
+osctl network config show
+
+# Set DNS servers
+osctl network dns set --nameserver 8.8.8.8 --nameserver 1.1.1.1
 ```

--- a/docs/using-osctl.md
+++ b/docs/using-osctl.md
@@ -33,24 +33,28 @@ cargo build --release --package osctl
 
 ---
 
-Every command requires a target node address:
+## Connecting to a Node
+
+Every command requires a target node endpoint:
 
 ```bash
-osctl --addr <NODE_IP>:50051 <command>
+osctl --endpoint http://<NODE_IP>:50051 <command>
 ```
 
 When testing locally with QEMU (using `run-qemu.sh`), the agent is forwarded to `localhost:50052`:
 
 ```bash
-osctl --addr 127.0.0.1:50052 <command>
+osctl --endpoint http://127.0.0.1:50052 <command>
 ```
+
+The default endpoint is `http://[::1]:50051` (IPv6 loopback).
 
 ## Commands
 
 ### Check Node Status
 
 ```bash
-osctl --addr 127.0.0.1:50052 status
+osctl --endpoint http://127.0.0.1:50052 status
 ```
 
 Returns system information including:
@@ -62,7 +66,7 @@ Returns system information including:
 ### Install an Update
 
 ```bash
-osctl --addr 127.0.0.1:50052 install --image oci://registry.example.com/keelos:1.0.1
+osctl --endpoint http://127.0.0.1:50052 update --source https://example.com/keelos-v0.2.0.squashfs
 ```
 
 This downloads the new OS image and writes it to the inactive partition. After installation, reboot to activate.
@@ -70,30 +74,56 @@ This downloads the new OS image and writes it to the inactive partition. After i
 ### Reboot the Node
 
 ```bash
-osctl --addr 127.0.0.1:50052 reboot
+osctl --endpoint http://127.0.0.1:50052 reboot
 ```
 
 Initiates a graceful shutdown of all services and reboots into the newly installed partition.
 
-### Stream Logs
+### Join a Kubernetes Cluster
 
 ```bash
-osctl --addr 127.0.0.1:50052 logs --component kubelet
-osctl --addr 127.0.0.1:50052 logs --component containerd
-osctl --addr 127.0.0.1:50052 logs --component agent
+osctl --endpoint http://127.0.0.1:50052 bootstrap \
+  --api-server https://k8s.example.com:6443 \
+  --token abcdef.0123456789abcdef \
+  --ca-cert ca.crt
 ```
 
-Streams real-time logs from the specified component.
+Configures kubelet TLS bootstrapping so the node can join a Kubernetes cluster. See the [Kubernetes Bootstrap Guide](docs/guides/kubernetes-bootstrap.md) for detailed instructions.
 
-### Network Configuration (Planned)
+### Check Bootstrap Status
 
 ```bash
-osctl --addr 127.0.0.1:50052 network set --ip 10.0.0.5/24 --gateway 10.0.0.1
+osctl --endpoint http://127.0.0.1:50052 bootstrap-status
+```
+
+Shows whether the node is bootstrapped and the connection details.
+
+### Network Configuration
+
+```bash
+# View network status
+osctl --endpoint http://127.0.0.1:50052 network status
+
+# Set static IP
+osctl --endpoint http://127.0.0.1:50052 network config set \
+  --interface eth0 --ip 10.0.0.5/24 --gateway 10.0.0.1
+
+# Set DNS servers
+osctl --endpoint http://127.0.0.1:50052 network dns set \
+  --nameserver 8.8.8.8 --nameserver 1.1.1.1
 ```
 
 ## Authentication
 
-> [!NOTE]
-> mTLS authentication is planned but not yet implemented in the alpha release.
+`osctl` supports mutual TLS (mTLS) for secure communication with `keel-agent`. Certificates are managed automatically via a local cert store.
 
-In production, `osctl` will require client certificates to authenticate with the agent.
+### Enable mTLS
+
+```bash
+# Generate a 24-hour bootstrap certificate
+osctl init bootstrap --node <NODE_IP>
+```
+
+After this, all subsequent `osctl` commands automatically use mTLS. The certificates are stored locally and `osctl` will select the best available certificate (preferring operational over bootstrap) on each connection.
+
+For full CLI reference, see [osctl Reference](docs/reference/osctl.md).


### PR DESCRIPTION
## Description

Update all documentation to accurately reflect the kubelet TLS bootstrap feature merged in PR #77.

### Changes (10 files, 291 insertions, 127 deletions)

- **kubernetes-bootstrap.md** — Comprehensive rewrite with 4-phase bootstrap lifecycle, key paths table
- **architecture.md** — Boot sequence diagram with persistent storage, cgroup v2 steps
- **first-boot.md** — Boot steps rewritten to match keel-init implementation
- **keel-init/README.md** — All responsibilities + kubelet modes table
- **reference/osctl.md** — Full rewrite with all current commands
- **using-osctl.md** — Fixed flags, added bootstrap/network sections
- **osctl/README.md** — Fixed flags, replaced stale commands
- **installation.md**, **local-qemu.md** — --addr → --endpoint
- **CHANGELOG.md** — Added [Unreleased] section

## Type of Change
- [x] Documentation update
