### PR TITLE
refactor: restructure Claude workflow into three specialized jobs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,15 +44,7 @@ jobs:
           model: claude-sonnet-4-6
           max_turns: "10"
           claude_args: |
-            --system-prompt "You are an AI assistant for the KeelOS project — an immutable, API-driven Linux distribution for Kubernetes workloads. Key rules:
-            - keel-init is PID 1 and must NEVER panic; always use Result<T, E> with the ? operator
-            - No unwrap() or expect() in runtime code (enforced by clippy::unwrap_used / expect_used)
-            - All system components are in Rust; tooling may use Go
-            - Statically link all binaries using x86_64-unknown-linux-musl
-            - Async code uses tokio; keel-init should remain synchronous where possible
-            - Commit messages follow Conventional Commits (feat:, fix:, docs:, chore:, etc.)
-            - Builds must run in a container via ./tools/builder/build.sh
-            - All new code requires unit tests in #[cfg(test)] modules"
+            --system-prompt "You are an AI assistant for the KeelOS project. Before responding to any request, read AGENTS.md at the root of this repository — it is the authoritative guide for project conventions, coding standards, terminology, and contribution rules. Follow it strictly."
 
   # ── Automatic PR Code Review ─────────────────────────────────────────────────
   # Runs a full code review automatically when a PR is opened or updated.


### PR DESCRIPTION
## Description

Restructures the Claude GitHub Actions workflow to split the monolithic `claude` job into three specialized, independently-triggered jobs with clear responsibilities:

1. **claude-assistant**: Interactive assistant that responds to `@claude` mentions in PR/issue comments, reviews, and newly-assigned issues. Simplified condition logic and reduced scope.

2. **pr-review**: Automatic code review that runs on every PR open/synchronize without requiring mentions. Implements comprehensive KeelOS-specific review criteria covering safety, code quality, static linking, testing, documentation, commit standards, and security.

3. **issue-triage**: Automatic issue triage that runs on new issues. Applies contextual labels (type, component, priority, status) and posts a structured triage comment with reproduction steps, affected components, and relevant documentation links.

### Key Changes

- **Simplified conditions**: Removed overly-broad `pull_request` trigger from assistant job; now only responds to explicit mentions or assignments
- **Dedicated PR review job**: Implements detailed, structured review guidance with blocking criteria (panics in PID 1, missing tests, unsafe without SAFETY comments, broken static linking, missing mTLS)
- **Dedicated issue triage job**: Automates label application and triage comments with component-specific guidance
- **Updated model & parameters**: Changed to `claude-sonnet-4-6` with appropriate `max_turns` for each job (10 for assistant, 5 for PR review, 3 for triage)
- **Simplified system prompt**: Assistant now delegates to `AGENTS.md` as the authoritative guide instead of embedding all rules
- **Improved documentation**: Added clear section headers and comments explaining each job's purpose and trigger conditions
- **Checkout optimization**: PR review uses `fetch-depth: 0` to access full history; others use `fetch-depth: 1`

## Type of Change

- [x] CI/CD changes
- [x] Refactoring (no functional changes)

## Release Note

```release-note
NONE
```

## Documentation

```documentation
NONE
```

https://claude.ai/code/session_01Q5DiiArUodydkY1Pe5Dy2h