### PR TITLE
docs: Add macOS build targets to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,12 @@ Use KeelOS-specific terms consistently:
 1. **No Panics in PID 1**: The `keel-init` binary is PID 1 and **must never panic**. Always use `Result<T, E>` with proper error handling.
 2. **Memory Safety**: All system components (PID 1, Agent) are written in **Rust**. Tooling may use Go.
 3. **Minimal Dependencies**: Audit every crate. Prefer `std` where possible.
-4. **Static Linking**: All OS image binaries target `x86_64-unknown-linux-musl`. `osctl` additionally ships `aarch64-unknown-linux-musl`, `armv7-unknown-linux-musleabihf`, and `x86_64-pc-windows-gnu` builds via `cross`.
+4. **Static Linking**: All OS image binaries target `x86_64-unknown-linux-musl`. `osctl` additionally ships the following targets via `cross`:
+   - `aarch64-unknown-linux-musl` — Linux ARM64
+   - `armv7-unknown-linux-musleabihf` — Linux ARMv7
+   - `x86_64-pc-windows-gnu` — Windows x86_64
+   - `x86_64-apple-darwin` — macOS Intel
+   - `aarch64-apple-darwin` — macOS Apple Silicon
 5. **Containerized Builds**: All builds must run inside a container for reproducibility:
    ```bash
    ./tools/builder/build.sh


### PR DESCRIPTION
## Description

Updates the AGENTS.md documentation to clarify the complete list of build targets supported by `osctl`. The static linking section now explicitly lists all five cross-compilation targets, including the two newly added macOS targets (`x86_64-apple-darwin` for Intel and `aarch64-apple-darwin` for Apple Silicon).

This change improves documentation clarity by:
- Converting a dense inline list to a structured bullet-point format
- Adding descriptive labels for each target (e.g., "Linux ARM64", "macOS Intel")
- Making it easier to discover and understand all supported platforms

**Which issue(s) this PR fixes**:
N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes
- [ ] Dependency updates

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE (documentation is the change itself)
```

https://claude.ai/code/session_01QwjPRrKssB3Ky9D2jdcqW6